### PR TITLE
[EXP][Command-Buffer] Optimize L0 command-buffer submission

### DIFF
--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -7814,6 +7814,7 @@ typedef struct ur_exp_command_buffer_desc_t {
     const void *pNext;         ///< [in][optional] pointer to extension-specific structure
     ur_bool_t isUpdatable;     ///< [in] Commands in a finalized command-buffer can be updated.
     ur_bool_t isInOrder;       ///< [in] Command-buffer can be submitted to in-order command-list.
+    ur_bool_t enableProfiling; ///< [in] Command-buffer profiling is enabled.
 
 } ur_exp_command_buffer_desc_t;
 

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -7813,6 +7813,7 @@ typedef struct ur_exp_command_buffer_desc_t {
                                ///< ::UR_STRUCTURE_TYPE_EXP_COMMAND_BUFFER_DESC
     const void *pNext;         ///< [in][optional] pointer to extension-specific structure
     ur_bool_t isUpdatable;     ///< [in] Commands in a finalized command-buffer can be updated.
+    ur_bool_t isInOrder;       ///< [in] Command-buffer can be submitted to in-order command-list.
 
 } ur_exp_command_buffer_desc_t;
 

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -7813,7 +7813,8 @@ typedef struct ur_exp_command_buffer_desc_t {
                                ///< ::UR_STRUCTURE_TYPE_EXP_COMMAND_BUFFER_DESC
     const void *pNext;         ///< [in][optional] pointer to extension-specific structure
     ur_bool_t isUpdatable;     ///< [in] Commands in a finalized command-buffer can be updated.
-    ur_bool_t isInOrder;       ///< [in] Command-buffer can be submitted to in-order command-list.
+    ur_bool_t isInOrder;       ///< [in] Commands in a command-buffer may be executed in-order without
+                               ///< explicit dependencies.
     ur_bool_t enableProfiling; ///< [in] Command-buffer profiling is enabled.
 
 } ur_exp_command_buffer_desc_t;

--- a/include/ur_print.hpp
+++ b/include/ur_print.hpp
@@ -9400,6 +9400,11 @@ inline std::ostream &operator<<(std::ostream &os, const struct ur_exp_command_bu
 
     os << (params.isInOrder);
 
+    os << ", ";
+    os << ".enableProfiling = ";
+
+    os << (params.enableProfiling);
+
     os << "}";
     return os;
 }

--- a/include/ur_print.hpp
+++ b/include/ur_print.hpp
@@ -9395,6 +9395,11 @@ inline std::ostream &operator<<(std::ostream &os, const struct ur_exp_command_bu
 
     os << (params.isUpdatable);
 
+    os << ", ";
+    os << ".isInOrder = ";
+
+    os << (params.isInOrder);
+
     os << "}";
     return os;
 }

--- a/scripts/core/EXP-COMMAND-BUFFER.rst
+++ b/scripts/core/EXP-COMMAND-BUFFER.rst
@@ -82,6 +82,7 @@ constructed. The members defined in ${x}_exp_command_buffer_desc_t are:
 command-buffer commands`.
 * ``isInOrder``, which should be set to ``true`` to enable the graph workload
   to be submitted to an in-order command-list.
+* ``enableProfiling``, which should be set to ``true`` to enable graph profling.
 
 Command-buffers are reference counted and can be retained and released by
 calling ${x}CommandBufferRetainExp and ${x}CommandBufferReleaseExp respectively.

--- a/scripts/core/EXP-COMMAND-BUFFER.rst
+++ b/scripts/core/EXP-COMMAND-BUFFER.rst
@@ -77,9 +77,11 @@ Command-Buffer Creation
 Command-Buffers are tied to a specific ${x}_context_handle_t and
 ${x}_device_handle_t. ${x}CommandBufferCreateExp optionally takes a descriptor
 to provide additional properties for how the command-buffer should be
-constructed. The only unique member defined in ${x}_exp_command_buffer_desc_t
-is ``isUpdatable``, which should be set to ``true`` to support :ref:`updating
+constructed. The members defined in ${x}_exp_command_buffer_desc_t are:
+* ``isUpdatable``, which should be set to ``true`` to support :ref:`updating
 command-buffer commands`.
+* ``isInOrder``, which should be set to ``true`` to enable the graph workload
+  to be submitted to an in-order command-list.
 
 Command-buffers are reference counted and can be retained and released by
 calling ${x}CommandBufferRetainExp and ${x}CommandBufferReleaseExp respectively.

--- a/scripts/core/exp-command-buffer.yml
+++ b/scripts/core/exp-command-buffer.yml
@@ -115,7 +115,10 @@ members:
       desc: "[in] Commands in a finalized command-buffer can be updated."
     - type: $x_bool_t
       name: isInOrder
-      desc: "[in] Command-buffer can be submitted to in-order commandd-list."
+      desc: "[in] Command-buffer can be submitted to in-order command-list."
+    - type: $x_bool_t
+      name: enableProfiling
+      desc: "[in] Command-buffer profiling is enabled."
 --- #--------------------------------------------------------------------------
 type: struct
 desc: "Descriptor type for updating a kernel command memobj argument."

--- a/scripts/core/exp-command-buffer.yml
+++ b/scripts/core/exp-command-buffer.yml
@@ -113,6 +113,9 @@ members:
     - type: $x_bool_t
       name: isUpdatable
       desc: "[in] Commands in a finalized command-buffer can be updated."
+    - type: $x_bool_t
+      name: isInOrder
+      desc: "[in] Command-buffer can be submitted to in-order commandd-list."
 --- #--------------------------------------------------------------------------
 type: struct
 desc: "Descriptor type for updating a kernel command memobj argument."

--- a/scripts/core/exp-command-buffer.yml
+++ b/scripts/core/exp-command-buffer.yml
@@ -115,7 +115,7 @@ members:
       desc: "[in] Commands in a finalized command-buffer can be updated."
     - type: $x_bool_t
       name: isInOrder
-      desc: "[in] Command-buffer can be submitted to in-order command-list."
+      desc: "[in] Commands in a command-buffer may be executed in-order without explicit dependencies."
     - type: $x_bool_t
       name: enableProfiling
       desc: "[in] Command-buffer profiling is enabled."

--- a/source/adapters/level_zero/command_buffer.cpp
+++ b/source/adapters/level_zero/command_buffer.cpp
@@ -169,8 +169,8 @@ ur_exp_command_buffer_handle_t_::~ur_exp_command_buffer_handle_t_() {
       // some other thread) then release referenced memory allocations. As a
       // result, memory can be deallocated and context can be removed from
       // container in the platform. That's why we need to lock a mutex here.
-      ur_platform_handle_t Plt = Kernel->Program->Context->getPlatform();
-      std::scoped_lock<ur_shared_mutex> ContextsLock(Plt->ContextsMutex);
+      ur_platform_handle_t Platform = Kernel->Program->Context->getPlatform();
+      std::scoped_lock<ur_shared_mutex> ContextsLock(Platform->ContextsMutex);
 
       if (--Kernel->SubmissionsCount == 0) {
         // Kernel is not submitted for execution, release referenced memory

--- a/source/adapters/level_zero/command_buffer.cpp
+++ b/source/adapters/level_zero/command_buffer.cpp
@@ -1062,7 +1062,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferEnqueueExp(
         SignalCommandList, false, false, true));
 
     if ((Queue->Properties & UR_QUEUE_FLAG_PROFILING_ENABLE) &&
-        (!CommandBuffer->IsInOrderCmdList)) {
+        (!CommandBuffer->IsInOrderCmdList) &&
+        (CommandBuffer->IsProfilingEnabled)) {
       // Multiple submissions of a command buffer implies that we need to save
       // the event timestamps before resubmiting the command buffer. We
       // therefore copy the these timestamps in a dedicated USM memory section

--- a/source/adapters/level_zero/command_buffer.cpp
+++ b/source/adapters/level_zero/command_buffer.cpp
@@ -353,7 +353,7 @@ static ur_result_t enqueueCommandBufferMemCopyHelper(
     UR_CALL(getEventsFromSyncPoints(CommandBuffer, NumSyncPointsInWaitList,
                                     SyncPointWaitList, ZeEventList));
     UR_CALL(EventCreate(CommandBuffer->Context, nullptr, false, false,
-                        CommandBuffer->IsProfilingEnabled, &LaunchEvent));
+                        !CommandBuffer->IsProfilingEnabled, &LaunchEvent));
     LaunchEvent->CommandType = CommandType;
 
     // Get sync point and register the event with it.
@@ -427,7 +427,7 @@ static ur_result_t enqueueCommandBufferMemCopyRectHelper(
 
     ur_event_handle_t LaunchEvent;
     UR_CALL(EventCreate(CommandBuffer->Context, nullptr, false, false,
-                        CommandBuffer->IsProfilingEnabled, &LaunchEvent));
+                        !CommandBuffer->IsProfilingEnabled, &LaunchEvent));
     LaunchEvent->CommandType = CommandType;
 
     // Get sync point and register the event with it.
@@ -479,7 +479,7 @@ static ur_result_t enqueueCommandBufferFillHelper(
 
     ur_event_handle_t LaunchEvent;
     UR_CALL(EventCreate(CommandBuffer->Context, nullptr, false, true,
-                        CommandBuffer->IsProfilingEnabled, &LaunchEvent));
+                        !CommandBuffer->IsProfilingEnabled, &LaunchEvent));
     LaunchEvent->CommandType = CommandType;
 
     // Get sync point and register the event with it.
@@ -543,10 +543,10 @@ urCommandBufferCreateExp(ur_context_handle_t Context, ur_device_handle_t Device,
   // on command-buffer enqueue.
   auto RetCommandBuffer = *CommandBuffer;
   UR_CALL(EventCreate(Context, nullptr, false, false,
-                      RetCommandBuffer->IsProfilingEnabled,
+                      !RetCommandBuffer->IsProfilingEnabled,
                       &RetCommandBuffer->SignalEvent));
   UR_CALL(EventCreate(Context, nullptr, false, false,
-                      RetCommandBuffer->IsProfilingEnabled,
+                      !RetCommandBuffer->IsProfilingEnabled,
                       &RetCommandBuffer->WaitEvent));
 
   // Add prefix commands
@@ -665,7 +665,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendKernelLaunchExp(
                                     SyncPointWaitList, ZeEventList));
     ur_event_handle_t LaunchEvent;
     UR_CALL(EventCreate(CommandBuffer->Context, nullptr, false, false,
-                        CommandBuffer->IsProfilingEnabled, &LaunchEvent));
+                        !CommandBuffer->IsProfilingEnabled, &LaunchEvent));
     LaunchEvent->CommandType = UR_COMMAND_KERNEL_LAUNCH;
 
     // Get sync point and register the event with it.
@@ -848,7 +848,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendUSMPrefetchExp(
 
     ur_event_handle_t LaunchEvent;
     UR_CALL(EventCreate(CommandBuffer->Context, nullptr, false, true,
-                        CommandBuffer->IsProfilingEnabled, &LaunchEvent));
+                        !CommandBuffer->IsProfilingEnabled, &LaunchEvent));
     LaunchEvent->CommandType = UR_COMMAND_USM_PREFETCH;
 
     // Get sync point and register the event with it.
@@ -918,7 +918,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendUSMAdviseExp(
 
     ur_event_handle_t LaunchEvent;
     UR_CALL(EventCreate(CommandBuffer->Context, nullptr, false, true,
-                        CommandBuffer->IsProfilingEnabled, &LaunchEvent));
+                        !CommandBuffer->IsProfilingEnabled, &LaunchEvent));
     LaunchEvent->CommandType = UR_COMMAND_USM_ADVISE;
 
     // Get sync point and register the event with it.

--- a/source/adapters/level_zero/command_buffer.cpp
+++ b/source/adapters/level_zero/command_buffer.cpp
@@ -94,8 +94,9 @@ namespace {
 /// @param VersionBuild Build verion number to compare to.
 /// @return true is the version of the driver is higher than or equal to the
 /// compared version
-bool CheckDriverVersion(ur_context_handle_t Context, uint32_t VersionMajor,
-                        uint32_t VersionMinor, uint32_t VersionBuild) {
+bool IsDriverVersionNewerOrSimilar(ur_context_handle_t Context,
+                                   uint32_t VersionMajor, uint32_t VersionMinor,
+                                   uint32_t VersionBuild) {
   ZeStruct<ze_driver_properties_t> ZeDriverProperties;
   ZE2UR_CALL(zeDriverGetProperties,
              (Context->getPlatform()->ZeDriver, &ZeDriverProperties));
@@ -503,7 +504,7 @@ urCommandBufferCreateExp(ur_context_handle_t Context, ur_device_handle_t Device,
                          const ur_exp_command_buffer_desc_t *CommandBufferDesc,
                          ur_exp_command_buffer_handle_t *CommandBuffer) {
   // In-order command-lists are not available in old driver version.
-  bool CompatibleDriver = CheckDriverVersion(Context, 1, 3, 28454);
+  bool CompatibleDriver = IsDriverVersionNewerOrSimilar(Context, 1, 3, 28454);
   const bool IsInOrder =
       CompatibleDriver
           ? (CommandBufferDesc ? CommandBufferDesc->isInOrder : false)

--- a/source/adapters/level_zero/command_buffer.cpp
+++ b/source/adapters/level_zero/command_buffer.cpp
@@ -118,7 +118,7 @@ ur_exp_command_buffer_handle_t_::ur_exp_command_buffer_handle_t_(
     : Context(Context), Device(Device), ZeCommandList(CommandList),
       ZeCommandListDesc(ZeDesc), ZeFencesList(), QueueProperties(),
       SyncPoints(), NextSyncPoint(0), IsInOrderCmdList(IsInOrderCmdList) {
-  IsProfilingEnabled = Desc->enableProfling;
+  IsProfilingEnabled = Desc->enableProfiling;
   urContextRetain(Context);
   urDeviceRetain(Device);
 }
@@ -543,10 +543,10 @@ urCommandBufferCreateExp(ur_context_handle_t Context, ur_device_handle_t Device,
   // on command-buffer enqueue.
   auto RetCommandBuffer = *CommandBuffer;
   UR_CALL(EventCreate(Context, nullptr, false, false,
-                      CommandBuffer->IsProfilingEnabled,
+                      RetCommandBuffer->IsProfilingEnabled,
                       &RetCommandBuffer->SignalEvent));
   UR_CALL(EventCreate(Context, nullptr, false, false,
-                      CommandBuffer->IsProfilingEnabled,
+                      RetCommandBuffer->IsProfilingEnabled,
                       &RetCommandBuffer->WaitEvent));
 
   // Add prefix commands

--- a/source/adapters/level_zero/command_buffer.cpp
+++ b/source/adapters/level_zero/command_buffer.cpp
@@ -318,14 +318,10 @@ static ur_result_t getEventsFromSyncPoints(
     size_t NumSyncPointsInWaitList,
     const ur_exp_command_buffer_sync_point_t *SyncPointWaitList,
     std::vector<ze_event_handle_t> &ZeEventList) {
-  // Map of ur_exp_command_buffer_sync_point_t to ur_event_handle_t defining
-  // the event associated with each sync-point
-  auto SyncPoints = CommandBuffer->SyncPoints;
-
   // For each sync-point add associated L0 event to the return list.
   for (size_t i = 0; i < NumSyncPointsInWaitList; i++) {
-    if (auto EventHandle = SyncPoints.find(SyncPointWaitList[i]);
-        EventHandle != SyncPoints.end()) {
+    if (auto EventHandle = CommandBuffer->SyncPoints.find(SyncPointWaitList[i]);
+        EventHandle != CommandBuffer->SyncPoints.end()) {
       ZeEventList.push_back(EventHandle->second->ZeEvent);
     } else {
       return UR_RESULT_ERROR_INVALID_VALUE;

--- a/source/adapters/level_zero/command_buffer.cpp
+++ b/source/adapters/level_zero/command_buffer.cpp
@@ -118,7 +118,7 @@ ur_exp_command_buffer_handle_t_::ur_exp_command_buffer_handle_t_(
     : Context(Context), Device(Device), ZeCommandList(CommandList),
       ZeCommandListDesc(ZeDesc), ZeFencesList(), QueueProperties(),
       SyncPoints(), NextSyncPoint(0), IsInOrderCmdList(IsInOrderCmdList) {
-  (void)Desc;
+  IsProfilingEnabled = Desc->enableProfling;
   urContextRetain(Context);
   urDeviceRetain(Device);
 }
@@ -353,7 +353,7 @@ static ur_result_t enqueueCommandBufferMemCopyHelper(
     UR_CALL(getEventsFromSyncPoints(CommandBuffer, NumSyncPointsInWaitList,
                                     SyncPointWaitList, ZeEventList));
     UR_CALL(EventCreate(CommandBuffer->Context, nullptr, false, false,
-                        &LaunchEvent));
+                        CommandBuffer->IsProfilingEnabled, &LaunchEvent));
     LaunchEvent->CommandType = CommandType;
 
     // Get sync point and register the event with it.
@@ -427,7 +427,7 @@ static ur_result_t enqueueCommandBufferMemCopyRectHelper(
 
     ur_event_handle_t LaunchEvent;
     UR_CALL(EventCreate(CommandBuffer->Context, nullptr, false, false,
-                        &LaunchEvent));
+                        CommandBuffer->IsProfilingEnabled, &LaunchEvent));
     LaunchEvent->CommandType = CommandType;
 
     // Get sync point and register the event with it.
@@ -479,7 +479,7 @@ static ur_result_t enqueueCommandBufferFillHelper(
 
     ur_event_handle_t LaunchEvent;
     UR_CALL(EventCreate(CommandBuffer->Context, nullptr, false, true,
-                        &LaunchEvent));
+                        CommandBuffer->IsProfilingEnabled, &LaunchEvent));
     LaunchEvent->CommandType = CommandType;
 
     // Get sync point and register the event with it.
@@ -543,8 +543,10 @@ urCommandBufferCreateExp(ur_context_handle_t Context, ur_device_handle_t Device,
   // on command-buffer enqueue.
   auto RetCommandBuffer = *CommandBuffer;
   UR_CALL(EventCreate(Context, nullptr, false, false,
+                      CommandBuffer->IsProfilingEnabled,
                       &RetCommandBuffer->SignalEvent));
   UR_CALL(EventCreate(Context, nullptr, false, false,
+                      CommandBuffer->IsProfilingEnabled,
                       &RetCommandBuffer->WaitEvent));
 
   // Add prefix commands
@@ -663,7 +665,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendKernelLaunchExp(
                                     SyncPointWaitList, ZeEventList));
     ur_event_handle_t LaunchEvent;
     UR_CALL(EventCreate(CommandBuffer->Context, nullptr, false, false,
-                        &LaunchEvent));
+                        CommandBuffer->IsProfilingEnabled, &LaunchEvent));
     LaunchEvent->CommandType = UR_COMMAND_KERNEL_LAUNCH;
 
     // Get sync point and register the event with it.
@@ -846,7 +848,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendUSMPrefetchExp(
 
     ur_event_handle_t LaunchEvent;
     UR_CALL(EventCreate(CommandBuffer->Context, nullptr, false, true,
-                        &LaunchEvent));
+                        CommandBuffer->IsProfilingEnabled, &LaunchEvent));
     LaunchEvent->CommandType = UR_COMMAND_USM_PREFETCH;
 
     // Get sync point and register the event with it.
@@ -916,7 +918,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendUSMAdviseExp(
 
     ur_event_handle_t LaunchEvent;
     UR_CALL(EventCreate(CommandBuffer->Context, nullptr, false, true,
-                        &LaunchEvent));
+                        CommandBuffer->IsProfilingEnabled, &LaunchEvent));
     LaunchEvent->CommandType = UR_COMMAND_USM_ADVISE;
 
     // Get sync point and register the event with it.

--- a/source/adapters/level_zero/command_buffer.cpp
+++ b/source/adapters/level_zero/command_buffer.cpp
@@ -1059,7 +1059,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferEnqueueExp(
         Queue, &RetEvent, UR_COMMAND_COMMAND_BUFFER_ENQUEUE_EXP,
         SignalCommandList, false, false, true));
 
-    if ((Queue->Properties & UR_QUEUE_FLAG_PROFILING_ENABLE)) {
+    if ((Queue->Properties & UR_QUEUE_FLAG_PROFILING_ENABLE) &&
+        (!CommandBuffer->IsInOrderCmdList)) {
       // Multiple submissions of a command buffer implies that we need to save
       // the event timestamps before resubmiting the command buffer. We
       // therefore copy the these timestamps in a dedicated USM memory section

--- a/source/adapters/level_zero/command_buffer.hpp
+++ b/source/adapters/level_zero/command_buffer.hpp
@@ -29,7 +29,8 @@ struct ur_exp_command_buffer_handle_t_ : public _ur_object {
                                   ur_device_handle_t Device,
                                   ze_command_list_handle_t CommandList,
                                   ZeStruct<ze_command_list_desc_t> ZeDesc,
-                                  const ur_exp_command_buffer_desc_t *Desc);
+                                  const ur_exp_command_buffer_desc_t *Desc,
+                                  const bool IsInOrderCmdList);
 
   ~ur_exp_command_buffer_handle_t_();
 

--- a/source/adapters/level_zero/command_buffer.hpp
+++ b/source/adapters/level_zero/command_buffer.hpp
@@ -71,6 +71,8 @@ struct ur_exp_command_buffer_handle_t_ : public _ur_object {
   // Event which a command-buffer waits on until the wait-list dependencies
   // passed to a command-buffer enqueue have been satisfied.
   ur_event_handle_t WaitEvent = nullptr;
+  // Command-buffer profiling is enabled.
+  bool IsProfilingEnabled = false;
   // Command-buffer can be submitted to an in-order command-list.
   bool IsInOrderCmdList;
   // List of kernels.

--- a/source/adapters/level_zero/command_buffer.hpp
+++ b/source/adapters/level_zero/command_buffer.hpp
@@ -76,5 +76,5 @@ struct ur_exp_command_buffer_handle_t_ : public _ur_object {
   // List of kernels.
   // This list is needed to release all kernels retained by the
   // command_buffer.
-  std::vector<ur_kernel_handle_t> kernelsList;
+  std::vector<ur_kernel_handle_t> KernelsList;
 };

--- a/source/adapters/level_zero/command_buffer.hpp
+++ b/source/adapters/level_zero/command_buffer.hpp
@@ -70,4 +70,10 @@ struct ur_exp_command_buffer_handle_t_ : public _ur_object {
   // Event which a command-buffer waits on until the wait-list dependencies
   // passed to a command-buffer enqueue have been satisfied.
   ur_event_handle_t WaitEvent = nullptr;
+  // Command-buffer can be submitted to an in-order command-list.
+  bool IsInOrderCmdList;
+  // List of kernels.
+  // This list is needed to release all kernels retained by the
+  // command_buffer.
+  std::vector<ur_kernel_handle_t> kernelsList;
 };

--- a/source/adapters/level_zero/event.cpp
+++ b/source/adapters/level_zero/event.cpp
@@ -752,7 +752,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urExtEventCreate(
     ur_event_handle_t
         *Event ///< [out] pointer to the handle of the event object created.
 ) {
-  UR_CALL(EventCreate(Context, nullptr, false, true, Event));
+  UR_CALL(EventCreate(Context, nullptr, false, true, false, Event));
 
   (*Event)->RefCountExternal++;
   ZE2UR_CALL(zeEventHostSignal, ((*Event)->ZeEvent));
@@ -770,7 +770,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventCreateWithNativeHandle(
   // we dont have urEventCreate, so use this check for now to know that
   // the call comes from urEventCreate()
   if (NativeEvent == nullptr) {
-    UR_CALL(EventCreate(Context, nullptr, false, true, Event));
+    UR_CALL(EventCreate(Context, nullptr, false, true, false, Event));
 
     (*Event)->RefCountExternal++;
     ZE2UR_CALL(zeEventHostSignal, ((*Event)->ZeEvent));
@@ -1049,9 +1049,11 @@ ur_result_t CleanupCompletedEvent(ur_event_handle_t Event, bool QueueLocked,
 //
 ur_result_t EventCreate(ur_context_handle_t Context, ur_queue_handle_t Queue,
                         bool IsMultiDevice, bool HostVisible,
+                        bool ForceDisableProfiling,
                         ur_event_handle_t *RetEvent) {
 
-  bool ProfilingEnabled = !Queue || Queue->isProfilingEnabled();
+  bool ProfilingEnabled =
+      ForceDisableProfiling ? false : (!Queue || Queue->isProfilingEnabled());
 
   ur_device_handle_t Device = nullptr;
 

--- a/source/adapters/level_zero/event.cpp
+++ b/source/adapters/level_zero/event.cpp
@@ -918,7 +918,6 @@ template <> ze_result_t zeHostSynchronize(ze_command_queue_handle_t Handle) {
 // If the caller locks queue mutex then it must pass 'true' to QueueLocked.
 ur_result_t CleanupCompletedEvent(ur_event_handle_t Event, bool QueueLocked,
                                   bool SetEventCompleted) {
-  ur_kernel_handle_t AssociatedKernel = nullptr;
   // List of dependent events.
   std::list<ur_event_handle_t> EventsToBeReleased;
   ur_queue_handle_t AssociatedQueue = nullptr;
@@ -931,14 +930,6 @@ ur_result_t CleanupCompletedEvent(ur_event_handle_t Event, bool QueueLocked,
       return UR_RESULT_SUCCESS;
 
     AssociatedQueue = Event->UrQueue;
-
-    // Remember the kernel associated with this event if there is one. We are
-    // going to release it later.
-    if (Event->CommandType == UR_COMMAND_KERNEL_LAUNCH && Event->CommandData) {
-      AssociatedKernel =
-          reinterpret_cast<ur_kernel_handle_t>(Event->CommandData);
-      Event->CommandData = nullptr;
-    }
 
     // Make a list of all the dependent events that must have signalled
     // because this event was dependent on them.
@@ -971,12 +962,6 @@ ur_result_t CleanupCompletedEvent(ur_event_handle_t Event, bool QueueLocked,
       }
     }
   };
-
-  // We've reset event data members above, now cleanup resources.
-  if (AssociatedKernel) {
-    ReleaseIndirectMem(AssociatedKernel);
-    UR_CALL(urKernelRelease(AssociatedKernel));
-  }
 
   if (AssociatedQueue) {
     {

--- a/source/adapters/level_zero/event.hpp
+++ b/source/adapters/level_zero/event.hpp
@@ -31,6 +31,7 @@ extern "C" {
 ur_result_t urEventReleaseInternal(ur_event_handle_t Event);
 ur_result_t EventCreate(ur_context_handle_t Context, ur_queue_handle_t Queue,
                         bool IsMultiDevice, bool HostVisible,
+                        bool ForceDisableProfiling,
                         ur_event_handle_t *RetEvent);
 } // extern "C"
 

--- a/source/adapters/level_zero/queue.cpp
+++ b/source/adapters/level_zero/queue.cpp
@@ -1517,7 +1517,7 @@ ur_result_t createEventAndAssociateQueue(ur_queue_handle_t Queue,
 
   if (*Event == nullptr)
     UR_CALL(EventCreate(Queue->Context, Queue, IsMultiDevice,
-                        HostVisible.value(), Event));
+                        HostVisible.value(), false, Event));
 
   (*Event)->UrQueue = Queue;
   (*Event)->CommandType = CommandType;


### PR DESCRIPTION
- Add support for use of in-order command-list for linear graph.
If the command-buffer is created with in-order command-list flag, an in-order command-list is created and the commands are enqueued without synchronization events.

- Add an `enableProfiling` propery.
If this property is not set, the profiling capability of events attached to the commands of the command-buffer is disabled.
The `EventCreate` function signature has been modified to allow us to create an event with the profiling capability disabled even if the event is created without a queue.

- Remove map copy in `getEventsFromSyncPoints` to reduce the finalization delay