### PR TITLE
Always use translated command-lists

### DIFF
--- a/source/adapters/level_zero/command_buffer.cpp
+++ b/source/adapters/level_zero/command_buffer.cpp
@@ -431,13 +431,11 @@ ur_result_t enqueueCommandBufferFillHelper(
 ur_exp_command_buffer_handle_t_::ur_exp_command_buffer_handle_t_(
     ur_context_handle_t Context, ur_device_handle_t Device,
     ze_command_list_handle_t CommandList,
-    ze_command_list_handle_t CommandListTranslated,
     ze_command_list_handle_t CommandListResetEvents,
     ze_command_list_handle_t CopyCommandList, ur_event_handle_t SignalEvent,
     ur_event_handle_t WaitEvent, ur_event_handle_t AllResetEvent,
     const ur_exp_command_buffer_desc_t *Desc, const bool IsInOrderCmdList)
     : Context(Context), Device(Device), ZeComputeCommandList(CommandList),
-      ZeComputeCommandListTranslated(CommandListTranslated),
       ZeCommandListResetEvents(CommandListResetEvents),
       ZeCopyCommandList(CopyCommandList), SignalEvent(SignalEvent),
       WaitEvent(WaitEvent), AllResetEvent(AllResetEvent), ZeFencesMap(),
@@ -702,11 +700,16 @@ urCommandBufferCreateExp(ur_context_handle_t Context, ur_device_handle_t Device,
              (ZEL_HANDLE_COMMAND_LIST, ZeComputeCommandList,
               (void **)&ZeComputeCommandListTranslated));
 
+  ze_command_list_handle_t ZeCopyCommandListTranslated = nullptr;
+  ZE2UR_CALL(zelLoaderTranslateHandle,
+             (ZEL_HANDLE_COMMAND_LIST, ZeCopyCommandList,
+              (void **)&ZeCopyCommandListTranslated));
+
   try {
     *CommandBuffer = new ur_exp_command_buffer_handle_t_(
-        Context, Device, ZeComputeCommandList, ZeComputeCommandListTranslated,
-        ZeCommandListResetEvents, ZeCopyCommandList, SignalEvent, WaitEvent,
-        AllResetEvent, CommandBufferDesc, IsInOrder);
+        Context, Device, ZeComputeCommandListTranslated,
+        ZeCommandListResetEvents, ZeCopyCommandListTranslated, SignalEvent,
+        WaitEvent, AllResetEvent, CommandBufferDesc, IsInOrder);
   } catch (const std::bad_alloc &) {
     return UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
   } catch (...) {
@@ -862,9 +865,9 @@ createCommandHandle(ur_exp_command_buffer_handle_t CommandBuffer,
                                ZE_MUTABLE_COMMAND_EXP_FLAG_GLOBAL_OFFSET;
 
   auto Platform = CommandBuffer->Context->getPlatform();
-  ZE2UR_CALL(Platform->ZeMutableCmdListExt.zexCommandListGetNextCommandIdExp,
-             (CommandBuffer->ZeComputeCommandListTranslated,
-              &ZeMutableCommandDesc, &CommandId));
+  ZE2UR_CALL(
+      Platform->ZeMutableCmdListExt.zexCommandListGetNextCommandIdExp,
+      (CommandBuffer->ZeComputeCommandList, &ZeMutableCommandDesc, &CommandId));
   DEBUG_LOG(CommandId);
 
   try {
@@ -1752,7 +1755,7 @@ ur_result_t updateKernelCommand(
   auto Platform = CommandBuffer->Context->getPlatform();
   ZE2UR_CALL(
       Platform->ZeMutableCmdListExt.zexCommandListUpdateMutableCommandsExp,
-      (CommandBuffer->ZeComputeCommandListTranslated, &MutableCommandDesc));
+      (CommandBuffer->ZeComputeCommandList, &MutableCommandDesc));
 
   return UR_RESULT_SUCCESS;
 }

--- a/source/adapters/level_zero/command_buffer.cpp
+++ b/source/adapters/level_zero/command_buffer.cpp
@@ -406,7 +406,7 @@ static ur_result_t enqueueCommandBufferMemCopyHelper(
   } else {
     // FIXME Why doesn't the event need to be host visible
     std::vector<ze_event_handle_t> ZeEventList;
-    ur_event_handle_t LaunchEvent;
+    ur_event_handle_t LaunchEvent = nullptr;
     UR_CALL(createSyncPoint(CommandType, CommandBuffer, NumSyncPointsInWaitList,
                             SyncPointWaitList, RetSyncPoint, false, ZeEventList,
                             LaunchEvent));
@@ -761,7 +761,7 @@ static ur_result_t
 createCommandHandle(ur_exp_command_buffer_handle_t CommandBuffer,
                     ur_kernel_handle_t Kernel, uint32_t WorkDim,
                     const size_t *LocalWorkSize,
-                    ur_exp_command_buffer_command_handle_t& Command) {
+                    ur_exp_command_buffer_command_handle_t &Command) {
 
   // If command-buffer is updatable then get command id which is going to be
   // used if command is updated in the future. This
@@ -1369,20 +1369,15 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferReleaseCommandExp(
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferUpdateKernelLaunchExp(
+static ur_result_t validateCommandDesc(
     ur_exp_command_buffer_command_handle_t Command,
     const ur_exp_command_buffer_update_kernel_launch_desc_t *CommandDesc) {
-  UR_ASSERT(Command->Kernel, UR_RESULT_ERROR_INVALID_NULL_HANDLE);
-  UR_ASSERT(CommandDesc->newWorkDim <= 3,
-            UR_RESULT_ERROR_INVALID_WORK_DIMENSION);
 
-  // Lock command, kernel and command buffer for update.
-  std::scoped_lock<ur_shared_mutex, ur_shared_mutex, ur_shared_mutex> Guard(
-      Command->Mutex, Command->CommandBuffer->Mutex, Command->Kernel->Mutex);
-  UR_ASSERT(Command->CommandBuffer->IsUpdatable,
-            UR_RESULT_ERROR_INVALID_OPERATION);
-  UR_ASSERT(Command->CommandBuffer->IsFinalized,
-            UR_RESULT_ERROR_INVALID_OPERATION);
+  auto CommandBuffer = Command->CommandBuffer;
+  auto SupportedFeatures =
+      Command->CommandBuffer->Device->ZeDeviceMutableCmdListsProperties
+          ->mutableCommandFlags;
+  logger::debug("Mutable features supported by device {}", SupportedFeatures);
 
   uint32_t Dim = CommandDesc->newWorkDim;
   if (Dim != 0) {
@@ -1407,25 +1402,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferUpdateKernelLaunchExp(
     }
   }
 
-  auto CommandBuffer = Command->CommandBuffer;
-  const void *NextDesc = nullptr;
-  auto SupportedFeatures =
-      Command->CommandBuffer->Device->ZeDeviceMutableCmdListsProperties
-          ->mutableCommandFlags;
-  logger::debug("Mutable features supported by device {}", SupportedFeatures);
-
-  // We need the created descriptors to live till the point when
-  // zexCommandListUpdateMutableCommandsExp is called at the end of the
-  // function.
-  std::vector<std::unique_ptr<ZeStruct<ze_mutable_kernel_argument_exp_desc_t>>>
-      ArgDescs;
-  std::vector<std::unique_ptr<ZeStruct<ze_mutable_global_offset_exp_desc_t>>>
-      OffsetDescs;
-  std::vector<std::unique_ptr<ZeStruct<ze_mutable_group_size_exp_desc_t>>>
-      GroupSizeDescs;
-  std::vector<std::unique_ptr<ZeStruct<ze_mutable_group_count_exp_desc_t>>>
-      GroupCountDescs;
-
   // Check if new global offset is provided.
   size_t *NewGlobalWorkOffset = CommandDesc->pNewGlobalWorkOffset;
   UR_ASSERT(!NewGlobalWorkOffset ||
@@ -1437,6 +1413,56 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferUpdateKernelLaunchExp(
       logger::error("No global offset extension found on this driver");
       return UR_RESULT_ERROR_INVALID_VALUE;
     }
+  }
+
+  // Check if new group size is provided.
+  size_t *NewLocalWorkSize = CommandDesc->pNewLocalWorkSize;
+  UR_ASSERT(!NewLocalWorkSize ||
+                (SupportedFeatures & ZE_MUTABLE_COMMAND_EXP_FLAG_GROUP_SIZE),
+            UR_RESULT_ERROR_UNSUPPORTED_FEATURE);
+
+  // Check if new global size is provided and we need to update group count.
+  size_t *NewGlobalWorkSize = CommandDesc->pNewGlobalWorkSize;
+  UR_ASSERT(!NewGlobalWorkSize ||
+                (SupportedFeatures & ZE_MUTABLE_COMMAND_EXP_FLAG_GROUP_COUNT),
+            UR_RESULT_ERROR_UNSUPPORTED_FEATURE);
+  UR_ASSERT(!(NewGlobalWorkSize && !NewLocalWorkSize) ||
+                (SupportedFeatures & ZE_MUTABLE_COMMAND_EXP_FLAG_GROUP_SIZE),
+            UR_RESULT_ERROR_UNSUPPORTED_FEATURE);
+
+  UR_ASSERT(
+      (!CommandDesc->numNewMemObjArgs && !CommandDesc->numNewPointerArgs &&
+       !CommandDesc->numNewValueArgs) ||
+          (SupportedFeatures & ZE_MUTABLE_COMMAND_EXP_FLAG_KERNEL_ARGUMENTS),
+      UR_RESULT_ERROR_UNSUPPORTED_FEATURE);
+
+  return UR_RESULT_SUCCESS;
+}
+
+static ur_result_t updateKernelCommand(
+    ur_exp_command_buffer_command_handle_t Command,
+    const ur_exp_command_buffer_update_kernel_launch_desc_t *CommandDesc) {
+
+  // We need the created descriptors to live till the point when
+  // zeCommandListUpdateMutableCommandsExp is called at the end of the
+  // function.
+  std::vector<std::variant<
+      std::unique_ptr<ZeStruct<ze_mutable_kernel_argument_exp_desc_t>>,
+      std::unique_ptr<ZeStruct<ze_mutable_global_offset_exp_desc_t>>,
+      std::unique_ptr<ZeStruct<ze_mutable_group_size_exp_desc_t>>,
+      std::unique_ptr<ZeStruct<ze_mutable_group_count_exp_desc_t>>>>
+      Descs;
+
+  const auto CommandBuffer = Command->CommandBuffer;
+  const void *NextDesc = nullptr;
+
+  uint32_t Dim = CommandDesc->newWorkDim;
+  size_t *NewGlobalWorkOffset = CommandDesc->pNewGlobalWorkOffset;
+  size_t *NewLocalWorkSize = CommandDesc->pNewLocalWorkSize;
+  size_t *NewGlobalWorkSize = CommandDesc->pNewGlobalWorkSize;
+
+  // Check if a new global offset is provided.
+  if (NewGlobalWorkOffset && Dim > 0) {
     auto MutableGroupOffestDesc =
         std::make_unique<ZeStruct<ze_mutable_global_offset_exp_desc_t>>();
     MutableGroupOffestDesc->commandId = Command->CommandId;
@@ -1449,15 +1475,12 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferUpdateKernelLaunchExp(
     DEBUG_LOG(MutableGroupOffestDesc->offsetY);
     MutableGroupOffestDesc->offsetZ = Dim == 3 ? NewGlobalWorkOffset[2] : 0;
     DEBUG_LOG(MutableGroupOffestDesc->offsetZ);
+
     NextDesc = MutableGroupOffestDesc.get();
-    OffsetDescs.push_back(std::move(MutableGroupOffestDesc));
+    Descs.push_back(std::move(MutableGroupOffestDesc));
   }
 
-  // Check if new group size is provided.
-  size_t *NewLocalWorkSize = CommandDesc->pNewLocalWorkSize;
-  UR_ASSERT(!NewLocalWorkSize ||
-                (SupportedFeatures & ZE_MUTABLE_COMMAND_EXP_FLAG_GROUP_SIZE),
-            UR_RESULT_ERROR_UNSUPPORTED_FEATURE);
+  // Check if a new group size is provided.
   if (NewLocalWorkSize && Dim > 0) {
     auto MutableGroupSizeDesc =
         std::make_unique<ZeStruct<ze_mutable_group_size_exp_desc_t>>();
@@ -1471,29 +1494,25 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferUpdateKernelLaunchExp(
     DEBUG_LOG(MutableGroupSizeDesc->groupSizeY);
     MutableGroupSizeDesc->groupSizeZ = Dim == 3 ? NewLocalWorkSize[2] : 1;
     DEBUG_LOG(MutableGroupSizeDesc->groupSizeZ);
+
     NextDesc = MutableGroupSizeDesc.get();
-    GroupSizeDescs.push_back(std::move(MutableGroupSizeDesc));
+    Descs.push_back(std::move(MutableGroupSizeDesc));
   }
 
-  // Check if new global size is provided and we need to update group count.
-  size_t *NewGlobalWorkSize = CommandDesc->pNewGlobalWorkSize;
-  UR_ASSERT(!NewGlobalWorkSize ||
-                (SupportedFeatures & ZE_MUTABLE_COMMAND_EXP_FLAG_GROUP_COUNT),
-            UR_RESULT_ERROR_UNSUPPORTED_FEATURE);
-  UR_ASSERT(!(NewGlobalWorkSize && !NewLocalWorkSize) ||
-                (SupportedFeatures & ZE_MUTABLE_COMMAND_EXP_FLAG_GROUP_SIZE),
-            UR_RESULT_ERROR_UNSUPPORTED_FEATURE);
-
+  // Check if a new global size is provided and if we need to update the group
+  // count.
   ze_group_count_t ZeThreadGroupDimensions{1, 1, 1};
   if (NewGlobalWorkSize && Dim > 0) {
-    uint32_t WG[3];
-    // If new global work size is provided but new local work size is not
-    // provided then we still need to update local work size based on size
-    // suggested by the driver for the kernel.
+    // If a new global work size is provided but a new local work size is not
+    // then we still need to update local work size based on the size suggested
+    // by the driver for the kernel.
     bool UpdateWGSize = NewLocalWorkSize == nullptr;
+
+    uint32_t WG[3];
     UR_CALL(calculateKernelWorkDimensions(
         Command->Kernel, CommandBuffer->Device, ZeThreadGroupDimensions, WG,
         Dim, NewGlobalWorkSize, NewLocalWorkSize));
+
     auto MutableGroupCountDesc =
         std::make_unique<ZeStruct<ze_mutable_group_count_exp_desc_t>>();
     MutableGroupCountDesc->commandId = Command->CommandId;
@@ -1504,8 +1523,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferUpdateKernelLaunchExp(
     DEBUG_LOG(MutableGroupCountDesc->pGroupCount->groupCountX);
     DEBUG_LOG(MutableGroupCountDesc->pGroupCount->groupCountY);
     DEBUG_LOG(MutableGroupCountDesc->pGroupCount->groupCountZ);
+
     NextDesc = MutableGroupCountDesc.get();
-    GroupCountDescs.push_back(std::move(MutableGroupCountDesc));
+    Descs.push_back(std::move(MutableGroupCountDesc));
 
     if (UpdateWGSize) {
       auto MutableGroupSizeDesc =
@@ -1522,15 +1542,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferUpdateKernelLaunchExp(
       DEBUG_LOG(MutableGroupSizeDesc->groupSizeZ);
 
       NextDesc = MutableGroupSizeDesc.get();
-      GroupSizeDescs.push_back(std::move(MutableGroupSizeDesc));
+      Descs.push_back(std::move(MutableGroupSizeDesc));
     }
   }
-
-  UR_ASSERT(
-      (!CommandDesc->numNewMemObjArgs && !CommandDesc->numNewPointerArgs &&
-       !CommandDesc->numNewValueArgs) ||
-          (SupportedFeatures & ZE_MUTABLE_COMMAND_EXP_FLAG_KERNEL_ARGUMENTS),
-      UR_RESULT_ERROR_UNSUPPORTED_FEATURE);
 
   // Check if new memory object arguments are provided.
   for (uint32_t NewMemObjArgNum = CommandDesc->numNewMemObjArgs;
@@ -1555,6 +1569,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferUpdateKernelLaunchExp(
         return UR_RESULT_ERROR_INVALID_ARGUMENT;
       }
     }
+
     ur_mem_handle_t NewMemObjArg = NewMemObjArgDesc.hNewMemObjArg;
     // The NewMemObjArg may be a NULL pointer in which case a NULL value is used
     // for the kernel argument declared as a pointer to global or constant
@@ -1564,6 +1579,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferUpdateKernelLaunchExp(
       UR_CALL(NewMemObjArg->getZeHandlePtr(ZeHandlePtr, UrAccessMode,
                                            CommandBuffer->Device));
     }
+
     auto ZeMutableArgDesc =
         std::make_unique<ZeStruct<ze_mutable_kernel_argument_exp_desc_t>>();
     ZeMutableArgDesc->commandId = Command->CommandId;
@@ -1578,7 +1594,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferUpdateKernelLaunchExp(
     DEBUG_LOG(ZeMutableArgDesc->pArgValue);
 
     NextDesc = ZeMutableArgDesc.get();
-    ArgDescs.push_back(std::move(ZeMutableArgDesc));
+    Descs.push_back(std::move(ZeMutableArgDesc));
   }
 
   // Check if there are new pointer arguments.
@@ -1586,6 +1602,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferUpdateKernelLaunchExp(
        NewPointerArgNum-- > 0;) {
     ur_exp_command_buffer_update_pointer_arg_desc_t NewPointerArgDesc =
         CommandDesc->pNewPointerArgList[NewPointerArgNum];
+
     auto ZeMutableArgDesc =
         std::make_unique<ZeStruct<ze_mutable_kernel_argument_exp_desc_t>>();
     ZeMutableArgDesc->commandId = Command->CommandId;
@@ -1600,7 +1617,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferUpdateKernelLaunchExp(
     DEBUG_LOG(ZeMutableArgDesc->pArgValue);
 
     NextDesc = ZeMutableArgDesc.get();
-    ArgDescs.push_back(std::move(ZeMutableArgDesc));
+    Descs.push_back(std::move(ZeMutableArgDesc));
   }
 
   // Check if there are new value arguments.
@@ -1608,6 +1625,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferUpdateKernelLaunchExp(
        NewValueArgNum-- > 0;) {
     ur_exp_command_buffer_update_value_arg_desc_t NewValueArgDesc =
         CommandDesc->pNewValueArgList[NewValueArgNum];
+
     auto ZeMutableArgDesc =
         std::make_unique<ZeStruct<ze_mutable_kernel_argument_exp_desc_t>>();
     ZeMutableArgDesc->commandId = Command->CommandId;
@@ -1632,18 +1650,14 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferUpdateKernelLaunchExp(
     }
     ZeMutableArgDesc->pArgValue = ArgValuePtr;
     DEBUG_LOG(ZeMutableArgDesc->pArgValue);
+
     NextDesc = ZeMutableArgDesc.get();
-    ArgDescs.push_back(std::move(ZeMutableArgDesc));
+    Descs.push_back(std::move(ZeMutableArgDesc));
   }
 
   ZeStruct<ze_mutable_commands_exp_desc_t> MutableCommandDesc;
   MutableCommandDesc.pNext = NextDesc;
   MutableCommandDesc.flags = 0;
-
-  // We must synchronize mutable command list execution before mutating.
-  if (ze_fence_handle_t &ZeFence = CommandBuffer->ZeActiveFence) {
-    ZE2UR_CALL(zeFenceHostSynchronize, (ZeFence, UINT64_MAX));
-  }
 
   auto Plt = CommandBuffer->Context->getPlatform();
   UR_ASSERT(Plt->ZeMutableCmdListExt.Supported,
@@ -1651,7 +1665,37 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferUpdateKernelLaunchExp(
   ZE2UR_CALL(
       Plt->ZeMutableCmdListExt.zexCommandListUpdateMutableCommandsExp,
       (CommandBuffer->ZeComputeCommandListTranslated, &MutableCommandDesc));
-  ZE2UR_CALL(zeCommandListClose, (CommandBuffer->ZeComputeCommandList));
+
+  return UR_RESULT_SUCCESS;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferUpdateKernelLaunchExp(
+    ur_exp_command_buffer_command_handle_t Command,
+    const ur_exp_command_buffer_update_kernel_launch_desc_t *CommandDesc) {
+  UR_ASSERT(Command->Kernel, UR_RESULT_ERROR_INVALID_NULL_HANDLE);
+  UR_ASSERT(CommandDesc->newWorkDim <= 3,
+            UR_RESULT_ERROR_INVALID_WORK_DIMENSION);
+
+  // Lock command, kernel and command buffer for update.
+  std::scoped_lock<ur_shared_mutex, ur_shared_mutex, ur_shared_mutex> Guard(
+      Command->Mutex, Command->CommandBuffer->Mutex, Command->Kernel->Mutex);
+
+  UR_ASSERT(Command->CommandBuffer->IsUpdatable,
+            UR_RESULT_ERROR_INVALID_OPERATION);
+  UR_ASSERT(Command->CommandBuffer->IsFinalized,
+            UR_RESULT_ERROR_INVALID_OPERATION);
+
+  UR_CALL(validateCommandDesc(Command, CommandDesc));
+
+  // We must synchronize mutable command list execution before mutating.
+  if (ze_fence_handle_t &ZeFence = Command->CommandBuffer->ZeActiveFence) {
+    ZE2UR_CALL(zeFenceHostSynchronize, (ZeFence, UINT64_MAX));
+  }
+
+  UR_CALL(updateKernelCommand(Command, CommandDesc));
+
+  ZE2UR_CALL(zeCommandListClose,
+             (Command->CommandBuffer->ZeComputeCommandList));
 
   return UR_RESULT_SUCCESS;
 }

--- a/source/adapters/level_zero/command_buffer.cpp
+++ b/source/adapters/level_zero/command_buffer.cpp
@@ -330,7 +330,6 @@ ur_result_t enqueueCommandBufferMemCopyHelper(
   ze_command_list_handle_t ZeCommandList =
       CommandBuffer->chooseCommandList(PreferCopyEngine);
 
-  logger::debug("calling zeCommandListAppendMemoryCopy()");
   ZE2UR_CALL(zeCommandListAppendMemoryCopy,
              (ZeCommandList, Dst, Src, Size, ZeLaunchEvent, ZeEventList.size(),
               getPointerFromVector(ZeEventList)));
@@ -389,7 +388,6 @@ ur_result_t enqueueCommandBufferMemCopyRectHelper(
   ze_command_list_handle_t ZeCommandList =
       CommandBuffer->chooseCommandList(PreferCopyEngine);
 
-  logger::debug("calling zeCommandListAppendMemoryCopyRegion()");
   ZE2UR_CALL(zeCommandListAppendMemoryCopyRegion,
              (ZeCommandList, Dst, &ZeDstRegion, DstPitch, DstSlicePitch, Src,
               &ZeSrcRegion, SrcPitch, SrcSlicePitch, ZeLaunchEvent,
@@ -422,7 +420,6 @@ ur_result_t enqueueCommandBufferFillHelper(
   ze_command_list_handle_t ZeCommandList =
       CommandBuffer->chooseCommandList(PreferCopyEngine);
 
-  logger::debug("calling zeCommandListAppendMemoryFill()");
   ZE2UR_CALL(zeCommandListAppendMemoryFill,
              (ZeCommandList, Ptr, Pattern, PatternSize, Size, ZeLaunchEvent,
               ZeEventList.size(), getPointerFromVector(ZeEventList)));
@@ -933,7 +930,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendKernelLaunchExp(
       UR_COMMAND_KERNEL_LAUNCH, CommandBuffer, NumSyncPointsInWaitList,
       SyncPointWaitList, false, RetSyncPoint, ZeEventList, ZeLaunchEvent));
 
-  logger::debug("calling zeCommandListAppendLaunchKernel()");
   ZE2UR_CALL(zeCommandListAppendLaunchKernel,
              (CommandBuffer->ZeComputeCommandList, Kernel->ZeKernel,
               &ZeThreadGroupDimensions, ZeLaunchEvent, ZeEventList.size(),

--- a/source/adapters/level_zero/command_buffer.cpp
+++ b/source/adapters/level_zero/command_buffer.cpp
@@ -620,9 +620,6 @@ ur_result_t createMainCommandList(ur_context_handle_t Context,
 
   ZeStruct<ze_mutable_command_list_exp_desc_t> ZeMutableCommandListDesc;
   if (IsUpdatable) {
-    auto Platform = Context->getPlatform();
-    UR_ASSERT(Platform->ZeMutableCmdListExt.Supported,
-              UR_RESULT_ERROR_UNSUPPORTED_FEATURE);
     ZeMutableCommandListDesc.flags = 0;
     ZeCommandListDesc.pNext = &ZeMutableCommandListDesc;
   }
@@ -659,6 +656,11 @@ urCommandBufferCreateExp(ur_context_handle_t Context, ur_device_handle_t Device,
   bool EnableProfiling =
       CommandBufferDesc && CommandBufferDesc->enableProfiling;
   bool IsUpdatable = CommandBufferDesc && CommandBufferDesc->isUpdatable;
+
+  if (IsUpdatable) {
+    UR_ASSERT(Context->getPlatform()->ZeMutableCmdListExt.Supported,
+              UR_RESULT_ERROR_UNSUPPORTED_FEATURE);
+  }
 
   ur_event_handle_t SignalEvent;
   ur_event_handle_t WaitEvent;

--- a/source/adapters/level_zero/command_buffer.cpp
+++ b/source/adapters/level_zero/command_buffer.cpp
@@ -1252,7 +1252,8 @@ namespace {
  * @param[out] ZeCommandQueue The L0 command queue.
  * @return UR_RESULT_SUCCESS or an error code on failure
  */
-ur_result_t getZeCommandQueue(ur_queue_handle_t Queue, bool UseCopyEngine,
+ur_result_t getZeCommandQueue(ur_queue_handle_legacy_t Queue,
+                              bool UseCopyEngine,
                               ze_command_queue_handle_t &ZeCommandQueue) {
   auto &QGroup = Queue->getQueueGroup(UseCopyEngine);
   uint32_t QueueGroupOrdinal;
@@ -1269,7 +1270,7 @@ ur_result_t getZeCommandQueue(ur_queue_handle_t Queue, bool UseCopyEngine,
  * @return UR_RESULT_SUCCESS or an error code on failure
  */
 ur_result_t waitForDependencies(ur_exp_command_buffer_handle_t CommandBuffer,
-                                ur_queue_handle_t Queue,
+                                ur_queue_handle_legacy_t Queue,
                                 uint32_t NumEventsInWaitList,
                                 const ur_event_handle_t *EventWaitList) {
   const bool UseCopyEngine = false;
@@ -1320,7 +1321,7 @@ ur_result_t waitForDependencies(ur_exp_command_buffer_handle_t CommandBuffer,
  * @return UR_RESULT_SUCCESS or an error code on failure
  */
 ur_result_t createUserEvent(ur_exp_command_buffer_handle_t CommandBuffer,
-                            ur_queue_handle_t Queue,
+                            ur_queue_handle_legacy_t Queue,
                             ur_command_list_ptr_t SignalCommandList,
                             ur_event_handle_t &Event) {
   // Execution event for this enqueue of the UR command-buffer

--- a/source/adapters/level_zero/command_buffer.cpp
+++ b/source/adapters/level_zero/command_buffer.cpp
@@ -19,13 +19,23 @@ https://github.com/intel/llvm/blob/sycl/sycl/doc/design/CommandGraph.md#level-ze
 #define DEBUG_LOG(VAR) logger::debug(#VAR " {}", VAR);
 
 namespace {
-/// Checks the version of the level-zero driver.
-/// @param Context Execution context
-/// @param VersionMajor Major verion number to compare to.
-/// @param VersionMinor Minor verion number to compare to.
-/// @param VersionBuild Build verion number to compare to.
-/// @return true is the version of the driver is higher than or equal to the
-/// compared version
+
+// Gets a C pointer from a vector. If the vector is empty returns nullptr
+// instead. This is different from the behaviour of the data() member function
+// of the vector class which might not return nullptr when the vector is empty.
+template <typename T> static T *getPointerFromVector(std::vector<T> &V) {
+  return V.size() == 0 ? nullptr : V.data();
+}
+
+/**
+ * Checks the version of the level-zero driver.
+ * @param[in] Context Execution context
+ * @param[in] VersionMajor Major version number to compare to.
+ * @param[in] VersionMinor Minor version number to compare to.
+ * @param[in] VersionBuild Build version number to compare to.
+ * @return true is the version of the driver is higher than or equal to the
+ * compared version.
+ */
 bool IsDriverVersionNewerOrSimilar(ur_context_handle_t Context,
                                    uint32_t VersionMajor, uint32_t VersionMinor,
                                    uint32_t VersionBuild) {
@@ -42,20 +52,64 @@ bool IsDriverVersionNewerOrSimilar(ur_context_handle_t Context,
           (DriverVersionBuild >= VersionBuild));
 }
 
-template <typename T> static T *getPointerFromVector(std::vector<T> &V) {
-  return V.size() == 0 ? nullptr : V.data();
-}
-
-// Default to using compute engine for fill operation, but allow to
-// override this with an environment variable.
-bool PreferCopyEngineForFill = [] {
+/**
+ * Default to using compute engine for fill operation, but allow to override
+ * this with an environment variable. Disable the copy engine if the pattern
+ * size is larger than the maximum supported.
+ * @param[in] CommandBuffer The CommandBuffer where the fill command will be
+ * appended.
+ * @param[in] PatternSize The pattern size for the fill command.
+ * @param[out] PreferCopyEngine Whether copy engine usage should be enabled or
+ * disabled for fill commands.
+ * @return UR_RESULT_SUCCESS or an error code on failure
+ */
+ur_result_t
+PreferCopyEngineForFill(ur_exp_command_buffer_handle_t CommandBuffer,
+                        size_t PatternSize, bool &PreferCopyEngine) {
   const char *UrRet = std::getenv("UR_L0_USE_COPY_ENGINE_FOR_FILL");
   const char *PiRet =
       std::getenv("SYCL_PI_LEVEL_ZERO_USE_COPY_ENGINE_FOR_FILL");
-  return (UrRet ? std::stoi(UrRet) : (PiRet ? std::stoi(PiRet) : 0));
-}();
 
-/// Helper function for calculating work dimensions for kernels
+  // If the copy engine available and PatternSize is valid, the command is
+  // enqueued in the ZeCopyCommandList, otherwise enqueue it in the compute
+  // command list.
+  PreferCopyEngine =
+      PatternSize <=
+      CommandBuffer->Device
+          ->QueueGroup[ur_device_handle_t_::queue_group_info_t::MainCopy]
+          .ZeProperties.maxMemoryFillPatternSize;
+
+  if (!PreferCopyEngine) {
+    // Pattern size must fit the compute queue capabilities.
+    UR_ASSERT(
+        PatternSize <=
+            CommandBuffer->Device
+                ->QueueGroup[ur_device_handle_t_::queue_group_info_t::Compute]
+                .ZeProperties.maxMemoryFillPatternSize,
+        UR_RESULT_ERROR_INVALID_VALUE);
+  }
+
+  PreferCopyEngine =
+      PreferCopyEngine &&
+      (UrRet ? std::stoi(UrRet) : (PiRet ? std::stoi(PiRet) : 0));
+
+  return UR_RESULT_SUCCESS;
+}
+
+/**
+ * Calculates a work group size for the kernel based on the GlobalWorkSize or
+ * the LocalWorkSize if provided.
+ * @param[in][optional] Kernel The Kernel. Used when LocalWorkSize is not
+ * provided.
+ * @param[in][optional] Device The device associated with the kernel. Used when
+ * LocalWorkSize is not provided.
+ * @param[out] ZeThreadGroupDimensions Number of work groups in each dimension.
+ * @param[out] WG The work group size for each dimension.
+ * @param[in] WorkDim The number of dimensions in the kernel.
+ * @param[in] GlobalWorkSize The global work size.
+ * @param[in][optional] LocalWorkSize The local work size.
+ * @return UR_RESULT_SUCCESS or an error code on failure.
+ */
 ur_result_t calculateKernelWorkDimensions(
     ur_kernel_handle_t Kernel, ur_device_handle_t Device,
     ze_group_count_t &ZeThreadGroupDimensions, uint32_t (&WG)[3],
@@ -166,18 +220,18 @@ ur_result_t calculateKernelWorkDimensions(
   return UR_RESULT_SUCCESS;
 }
 
-/// Helper function for finding the Level Zero events associated with the
-/// commands in a command-buffer, each event is pointed to by a sync-point in
-/// the wait list.
-///
-/// @param[in] CommandBuffer to lookup the L0 events from.
-/// @param[in] NumSyncPointsInWaitList Length of \p SyncPointWaitList.
-/// @param[in] SyncPointWaitList List of sync points in \p CommandBuffer
-/// to find the L0 events for.
-/// @param[out] ZeEventList Return parameter for the L0 events associated with
-/// each sync-point in \p SyncPointWaitList.
-///
-/// @return UR_RESULT_SUCCESS or an error code on failure
+/**
+ * Helper function for finding the Level Zero events associated with the
+ * commands in a command-buffer, each event is pointed to by a sync-point in the
+ * wait list.
+ * @param[in] CommandBuffer to lookup the L0 events from.
+ * @param[in] NumSyncPointsInWaitList Length of \p SyncPointWaitList.
+ * @param[in] SyncPointWaitList List of sync points in \p CommandBuffer to find
+ * the L0 events for.
+ * @param[out] ZeEventList Return parameter for the L0 events associated with
+ * each sync-point in \p SyncPointWaitList.
+ * @return UR_RESULT_SUCCESS or an error code on failure
+ */
 ur_result_t getEventsFromSyncPoints(
     const ur_exp_command_buffer_handle_t &CommandBuffer,
     size_t NumSyncPointsInWaitList,
@@ -198,7 +252,23 @@ ur_result_t getEventsFromSyncPoints(
   return UR_RESULT_SUCCESS;
 }
 
-
+/**
+ * If needed, creates a sync point for a given command.
+ * This operations is skipped if the command buffer is in order.
+ * @param[in] CommandType The type of the command.
+ * @param[in] CommandBuffer The CommandBuffer where the command is appended.
+ * @param[in] NumSyncPointsInWaitList Number of sync points that are
+ * dependencies for the command.
+ * @param[in] SyncPointWaitList List of sync point that are dependencies for the
+ * command.
+ * @param[out][optional] RetSyncPoint The new sync point.
+ * @param[in] host_visible Whether the event associated with the sync point
+ * should be host visible.
+ * @param[out] ZeEventList A list of L0 events that are dependencies for this
+ * sync point.
+ * @param[out] ZeLaunchEvent The L0 event associated with this sync point.
+ * @return UR_RESULT_SUCCESS or an error code on failure
+ */
 ur_result_t createSyncPointIfNeeded(
     ur_command_t CommandType, ur_exp_command_buffer_handle_t CommandBuffer,
     uint32_t NumSyncPointsInWaitList,
@@ -209,8 +279,6 @@ ur_result_t createSyncPointIfNeeded(
 
   ZeLaunchEvent = nullptr;
   if (!CommandBuffer->IsInOrderCmdList) {
-    //  std::vector<ze_event_handle_t> ZeEventList;
-    //  ur_event_handle_t LaunchEvent;
     UR_CALL(getEventsFromSyncPoints(CommandBuffer, NumSyncPointsInWaitList,
                                     SyncPointWaitList, ZeEventList));
     ur_event_handle_t LaunchEvent;
@@ -221,8 +289,6 @@ ur_result_t createSyncPointIfNeeded(
     ZeLaunchEvent = LaunchEvent->ZeEvent;
 
     // Get sync point and register the event with it.
-    // FIXME Refactor GetNextSyncPoint and RegisterSyncPoint seem redudant.
-    // Can be made into just one function.
     ur_exp_command_buffer_sync_point_t SyncPoint =
         CommandBuffer->GetNextSyncPoint();
     CommandBuffer->RegisterSyncPoint(SyncPoint, LaunchEvent);
@@ -245,7 +311,6 @@ ur_result_t enqueueCommandBufferMemCopyHelper(
     const ur_exp_command_buffer_sync_point_t *SyncPointWaitList,
     ur_exp_command_buffer_sync_point_t *RetSyncPoint) {
 
-  // FIXME Why doesn't the event need to be host visible
   std::vector<ze_event_handle_t> ZeEventList;
   ze_event_handle_t ZeLaunchEvent = nullptr;
   UR_CALL(createSyncPointIfNeeded(
@@ -305,7 +370,6 @@ ur_result_t enqueueCommandBufferMemCopyRectHelper(
   const ze_copy_region_t ZeDstRegion = {DstOriginX, DstOriginY, DstOriginZ,
                                         Width,      Height,     Depth};
 
-  // FIXME Why doesn't the event need to be host visible
   std::vector<ze_event_handle_t> ZeEventList;
   ze_event_handle_t ZeLaunchEvent = nullptr;
   UR_CALL(createSyncPointIfNeeded(
@@ -324,27 +388,29 @@ ur_result_t enqueueCommandBufferMemCopyRectHelper(
   return UR_RESULT_SUCCESS;
 }
 
-// Helper function for enqueuing memory fills
+// Helper function for enqueuing memory fills.
 ur_result_t enqueueCommandBufferFillHelper(
     ur_command_t CommandType, ur_exp_command_buffer_handle_t CommandBuffer,
     void *Ptr, const void *Pattern, size_t PatternSize, size_t Size,
-    bool PreferCopyEngine, uint32_t NumSyncPointsInWaitList,
+    uint32_t NumSyncPointsInWaitList,
     const ur_exp_command_buffer_sync_point_t *SyncPointWaitList,
     ur_exp_command_buffer_sync_point_t *RetSyncPoint) {
   // Pattern size must be a power of two.
   UR_ASSERT((PatternSize > 0) && ((PatternSize & (PatternSize - 1)) == 0),
             UR_RESULT_ERROR_INVALID_VALUE);
 
-  // FIXME Why does the event need to be host visible?
   std::vector<ze_event_handle_t> ZeEventList;
   ze_event_handle_t ZeLaunchEvent = nullptr;
   UR_CALL(createSyncPointIfNeeded(
       CommandType, CommandBuffer, NumSyncPointsInWaitList, SyncPointWaitList,
       RetSyncPoint, true, ZeEventList, ZeLaunchEvent));
 
+  bool PreferCopyEngine;
+  UR_CALL(
+      PreferCopyEngineForFill(CommandBuffer, PatternSize, PreferCopyEngine));
+
   ze_command_list_handle_t ZeCommandList;
-  UR_CALL(CommandBuffer->chooseCommandList(PreferCopyEngine, &ZeCommandList,
-                                           PatternSize));
+  UR_CALL(CommandBuffer->chooseCommandList(PreferCopyEngine, &ZeCommandList));
 
   logger::debug("calling zeCommandListAppendMemoryFill()");
   ZE2UR_CALL(zeCommandListAppendMemoryFill,
@@ -376,8 +442,8 @@ ur_exp_command_buffer_handle_t_::ur_exp_command_buffer_handle_t_(
   urDeviceRetain(Device);
 }
 
-// The ur_exp_command_buffer_handle_t_ destructor release all the memory objects
-// allocated for command_buffer managment
+// The ur_exp_command_buffer_handle_t_ destructor releases all the memory
+// objects allocated for command_buffer management.
 ur_exp_command_buffer_handle_t_::~ur_exp_command_buffer_handle_t_() {
   // Release the memory allocated to the Context stored in the command_buffer
   urContextRelease(Context);
@@ -485,11 +551,8 @@ void ur_exp_command_buffer_handle_t_::RegisterSyncPoint(
 
 ur_result_t ur_exp_command_buffer_handle_t_::chooseCommandList(
     bool PreferCopyEngine, ze_command_list_handle_t *ZeCommandList) {
-  // If the copy engine available, the command is enqueued in the
-  // ZeCopyCommandList.
   if (PreferCopyEngine && this->UseCopyEngine() && !this->IsInOrderCmdList) {
-    // We indicate that the ZeCopyCommandList contains commands to be
-    // submitted.
+    // We indicate that ZeCopyCommandList contains commands to be submitted.
     this->MCopyCommandListEmpty = false;
     *ZeCommandList = this->ZeCopyCommandList;
   }
@@ -497,38 +560,10 @@ ur_result_t ur_exp_command_buffer_handle_t_::chooseCommandList(
   return UR_RESULT_SUCCESS;
 }
 
-// FIXME Probably overkill?
-ur_result_t ur_exp_command_buffer_handle_t_::chooseCommandList(
-    bool PreferCopyEngine, ze_command_list_handle_t *ZeCommandList,
-    size_t PatternSize) {
-  // If the copy engine available and patternsize is valid, the command is
-  // enqueued in the ZeCopyCommandList, otherwise enqueue it in the compute
-  // command list.
-  PreferCopyEngine =
-      PreferCopyEngine &&
-      PatternSize <=
-          this->Device
-              ->QueueGroup[ur_device_handle_t_::queue_group_info_t::MainCopy]
-              .ZeProperties.maxMemoryFillPatternSize;
-
-  if (!PreferCopyEngine) {
-    // Pattern size must fit the compute queue capabilities.
-    UR_ASSERT(
-        PatternSize <=
-            this->Device
-                ->QueueGroup[ur_device_handle_t_::queue_group_info_t::Compute]
-                .ZeProperties.maxMemoryFillPatternSize,
-        UR_RESULT_ERROR_INVALID_VALUE);
-  }
-  UR_CALL(chooseCommandList(PreferCopyEngine, ZeCommandList));
-  return UR_RESULT_SUCCESS;
-}
-
-ur_result_t ur_exp_command_buffer_handle_t_::getFence(
+ur_result_t ur_exp_command_buffer_handle_t_::getFenceForQueue(
     ze_command_queue_handle_t &ZeCommandQueue, ze_fence_handle_t &ZeFence) {
   // If we already have created a fence for this queue, first reset then reuse
   // it, otherwise create a new fence.
-  //  ZeFence = this->ZeActiveFence;
   auto ZeWorkloadFenceForQueue = this->ZeFencesMap.find(ZeCommandQueue);
   if (ZeWorkloadFenceForQueue == this->ZeFencesMap.end()) {
     ZeStruct<ze_fence_desc_t> ZeFenceDesc;
@@ -542,17 +577,18 @@ ur_result_t ur_exp_command_buffer_handle_t_::getFence(
   return UR_RESULT_SUCCESS;
 }
 
-ur_result_t ur_exp_command_buffer_handle_t_::getZeCommandQueue(
-    ur_queue_handle_t Queue, bool UseCopyEngine,
-    ze_command_queue_handle_t &ZeCommandQueue) {
-  // Use compute engine rather than copy engine
-  auto &QGroup = Queue->getQueueGroup(UseCopyEngine);
-  uint32_t QueueGroupOrdinal;
-  ZeCommandQueue = QGroup.getZeQueue(&QueueGroupOrdinal);
-  return UR_RESULT_SUCCESS;
-}
-
 namespace {
+
+/**
+ * Creates a L0 command list
+ * @param[in] Context The Context associated with the command-list
+ * @param[in] Device  The Device associated with the command-list
+ * @param[in] IsInOrder Whether the command-list should be in-order.
+ * @param[in] isUpdatable Whether the command-list should be mutable.
+ * @param[in] isCopy Whether to use copy-engine for the the new command-list.
+ * @param[out] CommandList The L0 command-list created by this function.
+ * @return UR_RESULT_SUCCESS or an error code on failure
+ */
 ur_result_t createMainCommandList(ur_context_handle_t Context,
                                   ur_device_handle_t Device, bool IsInOrder,
                                   bool isUpdatable, bool isCopy,
@@ -585,19 +621,28 @@ ur_result_t createMainCommandList(ur_context_handle_t Context,
   return UR_RESULT_SUCCESS;
 }
 
-ur_result_t appendPreconditionEvents(ze_command_list_handle_t CommandList,
-                                     ur_event_handle_t WaitEvent,
-                                     ur_event_handle_t AllResetEvent) {
-  std::vector<ze_event_handle_t> PrecondEvents = {WaitEvent->ZeEvent,
-                                                  AllResetEvent->ZeEvent};
-  ZE2UR_CALL(
-      zeCommandListAppendBarrier,
-      (CommandList, nullptr, PrecondEvents.size(), PrecondEvents.data()));
+/**
+ * Appends a barrier to CommandList that waits for all the Events in EventList
+ * @param[in] CommandList The command-list where the barrier should be appended.
+ * @param[in] ZeEventList A list of events to wait for.
+ * @return UR_RESULT_SUCCESS or an error code on failure
+ */
+ur_result_t waitForEvents(ze_command_list_handle_t CommandList,
+                          std::vector<ze_event_handle_t> &ZeEventList) {
+  ZE2UR_CALL(zeCommandListAppendBarrier,
+             (CommandList, nullptr, ZeEventList.size(), ZeEventList.data()));
   return UR_RESULT_SUCCESS;
 }
 
-bool enableInOrder(ur_context_handle_t Context,
-                   const ur_exp_command_buffer_desc_t *CommandBufferDesc) {
+/**
+ * Checks whether the command buffer can be constructed using in order
+ * command-lists.
+ * @param[in] Context The Context associated with the command buffer.
+ * @param[in] CommandBufferDesc The description of the command buffer.
+ * @return Returns true if in order command-lists can be enabled.
+ */
+bool canBeInOrder(ur_context_handle_t Context,
+                  const ur_exp_command_buffer_desc_t *CommandBufferDesc) {
   // In-order command-lists are not available in old driver version.
   bool CompatibleDriver = IsDriverVersionNewerOrSimilar(Context, 1, 3, 28454);
   return CompatibleDriver
@@ -611,25 +656,28 @@ urCommandBufferCreateExp(ur_context_handle_t Context, ur_device_handle_t Device,
                          const ur_exp_command_buffer_desc_t *CommandBufferDesc,
                          ur_exp_command_buffer_handle_t *CommandBuffer) {
 
+  bool IsInOrder = canBeInOrder(Context, CommandBufferDesc);
+  bool enableProfiling =
+      CommandBufferDesc && CommandBufferDesc->enableProfiling;
+  bool IsUpdatable = CommandBufferDesc && CommandBufferDesc->isUpdatable;
+
   ur_event_handle_t SignalEvent;
   ur_event_handle_t WaitEvent;
   ur_event_handle_t AllResetEvent;
 
   UR_CALL(EventCreate(Context, nullptr, false, false, &SignalEvent, false,
-                      !CommandBufferDesc->enableProfiling));
+                      !enableProfiling));
   UR_CALL(EventCreate(Context, nullptr, false, false, &WaitEvent, false,
-                      !CommandBufferDesc->enableProfiling));
+                      !enableProfiling));
   UR_CALL(EventCreate(Context, nullptr, false, false, &AllResetEvent, false,
-                      !CommandBufferDesc->enableProfiling));
-
-  bool IsInOrder = enableInOrder(Context, CommandBufferDesc);
-  bool IsUpdatable = CommandBufferDesc && CommandBufferDesc->isUpdatable;
+                      !enableProfiling));
+  std::vector<ze_event_handle_t> PrecondEvents = {WaitEvent->ZeEvent,
+                                                  AllResetEvent->ZeEvent};
 
   ze_command_list_handle_t ZeComputeCommandList = nullptr;
   UR_CALL(createMainCommandList(Context, Device, IsInOrder, IsUpdatable, false,
                                 ZeComputeCommandList));
-  UR_CALL(
-      appendPreconditionEvents(ZeComputeCommandList, WaitEvent, AllResetEvent));
+  UR_CALL(waitForEvents(ZeComputeCommandList, PrecondEvents));
 
   ze_command_list_handle_t ZeCommandListResetEvents = nullptr;
   UR_CALL(createMainCommandList(Context, Device, false, false, false,
@@ -644,8 +692,7 @@ urCommandBufferCreateExp(ur_context_handle_t Context, ur_device_handle_t Device,
   if (Device->hasMainCopyEngine()) {
     UR_CALL(createMainCommandList(Context, Device, false, false, true,
                                   ZeCopyCommandList));
-    UR_CALL(
-        appendPreconditionEvents(ZeCopyCommandList, WaitEvent, AllResetEvent));
+    UR_CALL(waitForEvents(ZeCopyCommandList, PrecondEvents));
   }
 
   ze_command_list_handle_t ZeComputeCommandListTranslated = nullptr;
@@ -727,6 +774,16 @@ urCommandBufferFinalizeExp(ur_exp_command_buffer_handle_t CommandBuffer) {
 }
 
 namespace {
+
+/**
+ * Sets the global offset for a kernel command that will be appended to the
+ * command buffer.
+ * @param[in] CommandBuffer The CommandBuffer where the command will be
+ * appended.
+ * @param[in] Kernel The handle to the kernel that will be appended.
+ * @param[in] GlobalWorkOffset The global offset value.
+ * @return UR_RESULT_SUCCESS or an error code on failure
+ */
 ur_result_t setKernelGlobalOffset(ur_exp_command_buffer_handle_t CommandBuffer,
                                   ur_kernel_handle_t Kernel,
                                   const size_t *GlobalWorkOffset) {
@@ -744,6 +801,14 @@ ur_result_t setKernelGlobalOffset(ur_exp_command_buffer_handle_t CommandBuffer,
   return UR_RESULT_SUCCESS;
 }
 
+/**
+ * Sets the kernel arguments for a kernel command that will be appended to the
+ * command buffer.
+ * @param[in] CommandBuffer The CommandBuffer where the command will be
+ * appended.
+ * @param[in] Kernel The handle to the kernel that will be appended.
+ * @return UR_RESULT_SUCCESS or an error code on failure
+ */
 ur_result_t
 setKernelPendingArguments(ur_exp_command_buffer_handle_t CommandBuffer,
                           ur_kernel_handle_t Kernel) {
@@ -765,32 +830,43 @@ setKernelPendingArguments(ur_exp_command_buffer_handle_t CommandBuffer,
   return UR_RESULT_SUCCESS;
 }
 
+/**
+ * Creates a new command handle to use in future updates to the command buffer.
+ * @param[in] CommandBuffer The CommandBuffer associated with the new command.
+ * @param[in] Kernel  The Kernel associated with the new command.
+ * @param[in] WorkDim Dimensions of the kernel associated with the new command.
+ * @param[in] LocalWorkSize LocalWorkSize of the kernel associated with the new
+ * command.
+ * @param[out] Command The handle to the new command.
+ * @return UR_RESULT_SUCCESS or an error code on failure
+ */
 ur_result_t
 createCommandHandle(ur_exp_command_buffer_handle_t CommandBuffer,
                     ur_kernel_handle_t Kernel, uint32_t WorkDim,
                     const size_t *LocalWorkSize,
                     ur_exp_command_buffer_command_handle_t &Command) {
 
+  assert(CommandBuffer->IsUpdatable);
+
   // If command-buffer is updatable then get command id which is going to be
   // used if command is updated in the future. This
   // zeCommandListGetNextCommandIdExp can be called only if the command is
   // updatable.
   uint64_t CommandId = 0;
-  if (CommandBuffer->IsUpdatable) {
-    ZeStruct<ze_mutable_command_id_exp_desc_t> ZeMutableCommandDesc;
-    ZeMutableCommandDesc.flags = ZE_MUTABLE_COMMAND_EXP_FLAG_KERNEL_ARGUMENTS |
-                                 ZE_MUTABLE_COMMAND_EXP_FLAG_GROUP_COUNT |
-                                 ZE_MUTABLE_COMMAND_EXP_FLAG_GROUP_SIZE |
-                                 ZE_MUTABLE_COMMAND_EXP_FLAG_GLOBAL_OFFSET;
+  ZeStruct<ze_mutable_command_id_exp_desc_t> ZeMutableCommandDesc;
+  ZeMutableCommandDesc.flags = ZE_MUTABLE_COMMAND_EXP_FLAG_KERNEL_ARGUMENTS |
+                               ZE_MUTABLE_COMMAND_EXP_FLAG_GROUP_COUNT |
+                               ZE_MUTABLE_COMMAND_EXP_FLAG_GROUP_SIZE |
+                               ZE_MUTABLE_COMMAND_EXP_FLAG_GLOBAL_OFFSET;
 
-    auto Plt = CommandBuffer->Context->getPlatform();
-    UR_ASSERT(Plt->ZeMutableCmdListExt.Supported,
-              UR_RESULT_ERROR_UNSUPPORTED_FEATURE);
-    ZE2UR_CALL(Plt->ZeMutableCmdListExt.zexCommandListGetNextCommandIdExp,
-               (CommandBuffer->ZeComputeCommandListTranslated,
-                &ZeMutableCommandDesc, &CommandId));
-    DEBUG_LOG(CommandId);
-  }
+  auto Plt = CommandBuffer->Context->getPlatform();
+  UR_ASSERT(Plt->ZeMutableCmdListExt.Supported,
+            UR_RESULT_ERROR_UNSUPPORTED_FEATURE);
+  ZE2UR_CALL(Plt->ZeMutableCmdListExt.zexCommandListGetNextCommandIdExp,
+             (CommandBuffer->ZeComputeCommandListTranslated,
+              &ZeMutableCommandDesc, &CommandId));
+  DEBUG_LOG(CommandId);
+
   try {
     Command = new ur_exp_command_buffer_command_handle_t_(
         CommandBuffer, CommandId, WorkDim, LocalWorkSize != nullptr, Kernel);
@@ -1043,7 +1119,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendUSMPrefetchExp(
     ZE2UR_CALL(zeCommandListAppendMemoryPrefetch,
                (CommandBuffer->ZeComputeCommandList, Mem, Size));
   } else {
-    // FIXME Why does the event need to be host visible?
     std::vector<ze_event_handle_t> ZeEventList;
     ze_event_handle_t ZeLaunchEvent = nullptr;
     UR_CALL(createSyncPointIfNeeded(
@@ -1107,7 +1182,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendUSMAdviseExp(
                (CommandBuffer->ZeComputeCommandList,
                 CommandBuffer->Device->ZeDevice, Mem, Size, ZeAdvice));
   } else {
-    // FIMXE Why does the event need to be host visible?
     std::vector<ze_event_handle_t> ZeEventList;
     ze_event_handle_t ZeLaunchEvent = nullptr;
     UR_CALL(createSyncPointIfNeeded(
@@ -1151,8 +1225,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendMemBufferFillExp(
       UR_COMMAND_MEM_BUFFER_FILL, CommandBuffer, ZeHandleDst + Offset,
       Pattern,     // It will be interpreted as an 8-bit value,
       PatternSize, // which is indicated with this pattern_size==1
-      Size, PreferCopyEngineForFill, NumSyncPointsInWaitList, SyncPointWaitList,
-      SyncPoint);
+      Size, NumSyncPointsInWaitList, SyncPointWaitList, SyncPoint);
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendUSMFillExp(
@@ -1166,12 +1239,35 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendUSMFillExp(
       UR_COMMAND_MEM_BUFFER_FILL, CommandBuffer, Ptr,
       Pattern,     // It will be interpreted as an 8-bit value,
       PatternSize, // which is indicated with this pattern_size==1
-      Size, PreferCopyEngineForFill, NumSyncPointsInWaitList, SyncPointWaitList,
-      SyncPoint);
+      Size, NumSyncPointsInWaitList, SyncPointWaitList, SyncPoint);
 }
 
 namespace {
-// FIXME Refactor Document
+
+/**
+ * Gets an L0 command queue that supports the chosen engine.
+ * @param[in] Queue The UR queue used to submit the command buffer.
+ * @param[in] UseCopyEngine Which engine to use. true for the copy engine and
+ * false for the compute engine.
+ * @param[out] ZeCommandQueue The L0 command queue.
+ * @return UR_RESULT_SUCCESS or an error code on failure
+ */
+ur_result_t getZeCommandQueue(ur_queue_handle_t Queue, bool UseCopyEngine,
+                              ze_command_queue_handle_t &ZeCommandQueue) {
+  auto &QGroup = Queue->getQueueGroup(UseCopyEngine);
+  uint32_t QueueGroupOrdinal;
+  ZeCommandQueue = QGroup.getZeQueue(&QueueGroupOrdinal);
+  return UR_RESULT_SUCCESS;
+}
+
+/**
+ * Waits for the all the dependencies of the command buffer
+ * @param[in] CommandBuffer The command buffer.
+ * @param[in] Queue The UR queue used to submit the command buffer.
+ * @param[in] NumEventsInWaitList The number of events to wait for.
+ * @param[in] EventWaitList List of events to wait for.
+ * @return UR_RESULT_SUCCESS or an error code on failure
+ */
 ur_result_t waitForDependencies(ur_exp_command_buffer_handle_t CommandBuffer,
                                 ur_queue_handle_t Queue,
                                 uint32_t NumEventsInWaitList,
@@ -1214,7 +1310,15 @@ ur_result_t waitForDependencies(ur_exp_command_buffer_handle_t CommandBuffer,
   return UR_RESULT_SUCCESS;
 }
 
-// FIXME Refactor Document
+/**
+ * Creates a host visible event and appends a barrier to signal it when the
+ * command buffer finishes executing.
+ * @param[in] CommandBuffer The command buffer.
+ * @param[in] Queue The UR queue used to submit the command buffer.
+ * @param[in] SignalCommandList The command-list to append the barrier to.
+ * @param[out] Event The host visible event which will be returned to the user.
+ * @return UR_RESULT_SUCCESS or an error code on failure
+ */
 ur_result_t createUserEvent(ur_exp_command_buffer_handle_t CommandBuffer,
                             ur_queue_handle_t Queue,
                             ur_command_list_ptr_t SignalCommandList,
@@ -1268,10 +1372,10 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferEnqueueExp(
   std::scoped_lock<ur_shared_mutex> lock(Queue->Mutex);
 
   ze_command_queue_handle_t ZeCommandQueue;
-  CommandBuffer->getZeCommandQueue(Queue, false, ZeCommandQueue);
+  getZeCommandQueue(Queue, false, ZeCommandQueue);
 
   ze_fence_handle_t ZeFence;
-  CommandBuffer->getFence(ZeCommandQueue, ZeFence);
+  CommandBuffer->getFenceForQueue(ZeCommandQueue, ZeFence);
 
   UR_CALL(waitForDependencies(CommandBuffer, Queue, NumEventsInWaitList,
                               EventWaitList));
@@ -1296,7 +1400,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferEnqueueExp(
   // empty.
   if (!CommandBuffer->MCopyCommandListEmpty) {
     ze_command_queue_handle_t ZeCopyCommandQueue;
-    CommandBuffer->getZeCommandQueue(Queue, true, ZeCopyCommandQueue);
+    getZeCommandQueue(Queue, true, ZeCopyCommandQueue);
     ZE2UR_CALL(
         zeCommandQueueExecuteCommandLists,
         (ZeCopyCommandQueue, 1, &CommandBuffer->ZeCopyCommandList, nullptr));
@@ -1342,6 +1446,13 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferReleaseCommandExp(
 }
 
 namespace {
+
+/**
+ * Validates contents of the update command description.
+ * @param[in] Command The command which is being updated.
+ * @param[in] CommandDesc The update command description.
+ * @return UR_RESULT_SUCCESS or an error code on failure
+ */
 ur_result_t validateCommandDesc(
     ur_exp_command_buffer_command_handle_t Command,
     const ur_exp_command_buffer_update_kernel_launch_desc_t *CommandDesc) {
@@ -1412,6 +1523,12 @@ ur_result_t validateCommandDesc(
   return UR_RESULT_SUCCESS;
 }
 
+/**
+ * Update the kernel command with the new values.
+ * @param[in] Command The command which is being updated.
+ * @param[in] CommandDesc The update command description.
+ * @return UR_RESULT_SUCCESS or an error code on failure
+ */
 ur_result_t updateKernelCommand(
     ur_exp_command_buffer_command_handle_t Command,
     const ur_exp_command_buffer_update_kernel_launch_desc_t *CommandDesc) {

--- a/source/adapters/level_zero/command_buffer.cpp
+++ b/source/adapters/level_zero/command_buffer.cpp
@@ -42,6 +42,10 @@ bool IsDriverVersionNewerOrSimilar(ur_context_handle_t Context,
           (DriverVersionBuild >= VersionBuild));
 }
 
+template <typename T> static T *getPointerFromVector(std::vector<T> &V) {
+  return V.size() == 0 ? nullptr : V.data();
+}
+
 // Default to using compute engine for fill operation, but allow to
 // override this with an environment variable.
 bool PreferCopyEngineForFill = [] {
@@ -51,7 +55,305 @@ bool PreferCopyEngineForFill = [] {
   return (UrRet ? std::stoi(UrRet) : (PiRet ? std::stoi(PiRet) : 0));
 }();
 
-}; // namespace
+/// Helper function for calculating work dimensions for kernels
+ur_result_t calculateKernelWorkDimensions(
+    ur_kernel_handle_t Kernel, ur_device_handle_t Device,
+    ze_group_count_t &ZeThreadGroupDimensions, uint32_t (&WG)[3],
+    uint32_t WorkDim, const size_t *GlobalWorkSize,
+    const size_t *LocalWorkSize) {
+
+  UR_ASSERT(GlobalWorkSize, UR_RESULT_ERROR_INVALID_VALUE);
+  // If LocalWorkSize is not provided then Kernel must be provided to query
+  // suggested group size.
+  UR_ASSERT(LocalWorkSize || Kernel, UR_RESULT_ERROR_INVALID_VALUE);
+
+  // New variable needed because GlobalWorkSize parameter might not be of size
+  // 3
+  size_t GlobalWorkSize3D[3]{1, 1, 1};
+  std::copy(GlobalWorkSize, GlobalWorkSize + WorkDim, GlobalWorkSize3D);
+
+  if (LocalWorkSize) {
+    WG[0] = ur_cast<uint32_t>(LocalWorkSize[0]);
+    WG[1] = WorkDim >= 2 ? ur_cast<uint32_t>(LocalWorkSize[1]) : 1;
+    WG[2] = WorkDim == 3 ? ur_cast<uint32_t>(LocalWorkSize[2]) : 1;
+  } else {
+    // We can't call to zeKernelSuggestGroupSize if 64-bit GlobalWorkSize3D
+    // values do not fit to 32-bit that the API only supports currently.
+    bool SuggestGroupSize = true;
+    for (int I : {0, 1, 2}) {
+      if (GlobalWorkSize3D[I] > UINT32_MAX) {
+        SuggestGroupSize = false;
+      }
+    }
+    if (SuggestGroupSize) {
+      ZE2UR_CALL(zeKernelSuggestGroupSize,
+                 (Kernel->ZeKernel, GlobalWorkSize3D[0], GlobalWorkSize3D[1],
+                  GlobalWorkSize3D[2], &WG[0], &WG[1], &WG[2]));
+    } else {
+      for (int I : {0, 1, 2}) {
+        // Try to find a I-dimension WG size that the GlobalWorkSize3D[I] is
+        // fully divisable with. Start with the max possible size in
+        // each dimension.
+        uint32_t GroupSize[] = {
+            Device->ZeDeviceComputeProperties->maxGroupSizeX,
+            Device->ZeDeviceComputeProperties->maxGroupSizeY,
+            Device->ZeDeviceComputeProperties->maxGroupSizeZ};
+        GroupSize[I] = (std::min)(size_t(GroupSize[I]), GlobalWorkSize3D[I]);
+        while (GlobalWorkSize3D[I] % GroupSize[I]) {
+          --GroupSize[I];
+        }
+        if (GlobalWorkSize[I] / GroupSize[I] > UINT32_MAX) {
+          logger::debug("calculateKernelWorkDimensions: can't find a WG size "
+                        "suitable for global work size > UINT32_MAX");
+          return UR_RESULT_ERROR_INVALID_WORK_GROUP_SIZE;
+        }
+        WG[I] = GroupSize[I];
+      }
+      logger::debug("calculateKernelWorkDimensions: using computed WG "
+                    "size = {{{}, {}, {}}}",
+                    WG[0], WG[1], WG[2]);
+    }
+  }
+
+  // TODO: assert if sizes do not fit into 32-bit?
+  switch (WorkDim) {
+  case 3:
+    ZeThreadGroupDimensions.groupCountX =
+        ur_cast<uint32_t>(GlobalWorkSize3D[0] / WG[0]);
+    ZeThreadGroupDimensions.groupCountY =
+        ur_cast<uint32_t>(GlobalWorkSize3D[1] / WG[1]);
+    ZeThreadGroupDimensions.groupCountZ =
+        ur_cast<uint32_t>(GlobalWorkSize3D[2] / WG[2]);
+    break;
+  case 2:
+    ZeThreadGroupDimensions.groupCountX =
+        ur_cast<uint32_t>(GlobalWorkSize3D[0] / WG[0]);
+    ZeThreadGroupDimensions.groupCountY =
+        ur_cast<uint32_t>(GlobalWorkSize3D[1] / WG[1]);
+    WG[2] = 1;
+    break;
+  case 1:
+    ZeThreadGroupDimensions.groupCountX =
+        ur_cast<uint32_t>(GlobalWorkSize3D[0] / WG[0]);
+    WG[1] = WG[2] = 1;
+    break;
+
+  default:
+    logger::error("calculateKernelWorkDimensions: unsupported work_dim");
+    return UR_RESULT_ERROR_INVALID_VALUE;
+  }
+
+  // Error handling for non-uniform group size case
+  if (GlobalWorkSize3D[0] !=
+      size_t(ZeThreadGroupDimensions.groupCountX) * WG[0]) {
+    logger::error("calculateKernelWorkDimensions: invalid work_dim. The range "
+                  "is not a multiple of the group size in the 1st dimension");
+    return UR_RESULT_ERROR_INVALID_WORK_GROUP_SIZE;
+  }
+  if (GlobalWorkSize3D[1] !=
+      size_t(ZeThreadGroupDimensions.groupCountY) * WG[1]) {
+    logger::error("calculateKernelWorkDimensions: invalid work_dim. The range "
+                  "is not a multiple of the group size in the 2nd dimension");
+    return UR_RESULT_ERROR_INVALID_WORK_GROUP_SIZE;
+  }
+  if (GlobalWorkSize3D[2] !=
+      size_t(ZeThreadGroupDimensions.groupCountZ) * WG[2]) {
+    logger::error("calculateKernelWorkDimensions: invalid work_dim. The range "
+                  "is not a multiple of the group size in the 3rd dimension");
+    return UR_RESULT_ERROR_INVALID_WORK_GROUP_SIZE;
+  }
+
+  return UR_RESULT_SUCCESS;
+}
+
+/// Helper function for finding the Level Zero events associated with the
+/// commands in a command-buffer, each event is pointed to by a sync-point in
+/// the wait list.
+///
+/// @param[in] CommandBuffer to lookup the L0 events from.
+/// @param[in] NumSyncPointsInWaitList Length of \p SyncPointWaitList.
+/// @param[in] SyncPointWaitList List of sync points in \p CommandBuffer
+/// to find the L0 events for.
+/// @param[out] ZeEventList Return parameter for the L0 events associated with
+/// each sync-point in \p SyncPointWaitList.
+///
+/// @return UR_RESULT_SUCCESS or an error code on failure
+ur_result_t getEventsFromSyncPoints(
+    const ur_exp_command_buffer_handle_t &CommandBuffer,
+    size_t NumSyncPointsInWaitList,
+    const ur_exp_command_buffer_sync_point_t *SyncPointWaitList,
+    std::vector<ze_event_handle_t> &ZeEventList) {
+  if (!SyncPointWaitList || NumSyncPointsInWaitList == 0)
+    return UR_RESULT_SUCCESS;
+
+  // For each sync-point add associated L0 event to the return list.
+  for (size_t i = 0; i < NumSyncPointsInWaitList; i++) {
+    if (auto EventHandle = CommandBuffer->SyncPoints.find(SyncPointWaitList[i]);
+        EventHandle != CommandBuffer->SyncPoints.end()) {
+      ZeEventList.push_back(EventHandle->second->ZeEvent);
+    } else {
+      return UR_RESULT_ERROR_INVALID_VALUE;
+    }
+  }
+  return UR_RESULT_SUCCESS;
+}
+
+
+ur_result_t createSyncPointIfNeeded(
+    ur_command_t CommandType, ur_exp_command_buffer_handle_t CommandBuffer,
+    uint32_t NumSyncPointsInWaitList,
+    const ur_exp_command_buffer_sync_point_t *SyncPointWaitList,
+    ur_exp_command_buffer_sync_point_t *RetSyncPoint, bool host_visible,
+    std::vector<ze_event_handle_t> &ZeEventList,
+    ze_event_handle_t &ZeLaunchEvent) {
+
+  ZeLaunchEvent = nullptr;
+  if (!CommandBuffer->IsInOrderCmdList) {
+    //  std::vector<ze_event_handle_t> ZeEventList;
+    //  ur_event_handle_t LaunchEvent;
+    UR_CALL(getEventsFromSyncPoints(CommandBuffer, NumSyncPointsInWaitList,
+                                    SyncPointWaitList, ZeEventList));
+    ur_event_handle_t LaunchEvent;
+    UR_CALL(EventCreate(CommandBuffer->Context, nullptr, false, host_visible,
+                        &LaunchEvent, false,
+                        !CommandBuffer->IsProfilingEnabled));
+    LaunchEvent->CommandType = CommandType;
+    ZeLaunchEvent = LaunchEvent->ZeEvent;
+
+    // Get sync point and register the event with it.
+    // FIXME Refactor GetNextSyncPoint and RegisterSyncPoint seem redudant.
+    // Can be made into just one function.
+    ur_exp_command_buffer_sync_point_t SyncPoint =
+        CommandBuffer->GetNextSyncPoint();
+    CommandBuffer->RegisterSyncPoint(SyncPoint, LaunchEvent);
+
+    if (RetSyncPoint) {
+      *RetSyncPoint = SyncPoint;
+    }
+  }
+
+  return UR_RESULT_SUCCESS;
+}
+
+// Shared by all memory read/write/copy PI interfaces.
+// Helper function for common code when enqueuing memory operations to a command
+// buffer.
+ur_result_t enqueueCommandBufferMemCopyHelper(
+    ur_command_t CommandType, ur_exp_command_buffer_handle_t CommandBuffer,
+    void *Dst, const void *Src, size_t Size, bool PreferCopyEngine,
+    uint32_t NumSyncPointsInWaitList,
+    const ur_exp_command_buffer_sync_point_t *SyncPointWaitList,
+    ur_exp_command_buffer_sync_point_t *RetSyncPoint) {
+
+  // FIXME Why doesn't the event need to be host visible
+  std::vector<ze_event_handle_t> ZeEventList;
+  ze_event_handle_t ZeLaunchEvent = nullptr;
+  UR_CALL(createSyncPointIfNeeded(
+      CommandType, CommandBuffer, NumSyncPointsInWaitList, SyncPointWaitList,
+      RetSyncPoint, false, ZeEventList, ZeLaunchEvent));
+
+  ze_command_list_handle_t ZeCommandList;
+  UR_CALL(CommandBuffer->chooseCommandList(PreferCopyEngine, &ZeCommandList));
+
+  logger::debug("calling zeCommandListAppendMemoryCopy()");
+  ZE2UR_CALL(zeCommandListAppendMemoryCopy,
+             (ZeCommandList, Dst, Src, Size, ZeLaunchEvent, ZeEventList.size(),
+              getPointerFromVector(ZeEventList)));
+
+  return UR_RESULT_SUCCESS;
+}
+
+// Helper function for common code when enqueuing rectangular memory operations
+// to a command buffer.
+ur_result_t enqueueCommandBufferMemCopyRectHelper(
+    ur_command_t CommandType, ur_exp_command_buffer_handle_t CommandBuffer,
+    void *Dst, const void *Src, ur_rect_offset_t SrcOrigin,
+    ur_rect_offset_t DstOrigin, ur_rect_region_t Region, size_t SrcRowPitch,
+    size_t DstRowPitch, size_t SrcSlicePitch, size_t DstSlicePitch,
+    bool PreferCopyEngine, uint32_t NumSyncPointsInWaitList,
+    const ur_exp_command_buffer_sync_point_t *SyncPointWaitList,
+    ur_exp_command_buffer_sync_point_t *RetSyncPoint) {
+
+  uint32_t SrcOriginX = ur_cast<uint32_t>(SrcOrigin.x);
+  uint32_t SrcOriginY = ur_cast<uint32_t>(SrcOrigin.y);
+  uint32_t SrcOriginZ = ur_cast<uint32_t>(SrcOrigin.z);
+
+  uint32_t SrcPitch = SrcRowPitch;
+  if (SrcPitch == 0)
+    SrcPitch = ur_cast<uint32_t>(Region.width);
+
+  if (SrcSlicePitch == 0)
+    SrcSlicePitch = ur_cast<uint32_t>(Region.height) * SrcPitch;
+
+  uint32_t DstOriginX = ur_cast<uint32_t>(DstOrigin.x);
+  uint32_t DstOriginY = ur_cast<uint32_t>(DstOrigin.y);
+  uint32_t DstOriginZ = ur_cast<uint32_t>(DstOrigin.z);
+
+  uint32_t DstPitch = DstRowPitch;
+  if (DstPitch == 0)
+    DstPitch = ur_cast<uint32_t>(Region.width);
+
+  if (DstSlicePitch == 0)
+    DstSlicePitch = ur_cast<uint32_t>(Region.height) * DstPitch;
+
+  uint32_t Width = ur_cast<uint32_t>(Region.width);
+  uint32_t Height = ur_cast<uint32_t>(Region.height);
+  uint32_t Depth = ur_cast<uint32_t>(Region.depth);
+
+  const ze_copy_region_t ZeSrcRegion = {SrcOriginX, SrcOriginY, SrcOriginZ,
+                                        Width,      Height,     Depth};
+  const ze_copy_region_t ZeDstRegion = {DstOriginX, DstOriginY, DstOriginZ,
+                                        Width,      Height,     Depth};
+
+  // FIXME Why doesn't the event need to be host visible
+  std::vector<ze_event_handle_t> ZeEventList;
+  ze_event_handle_t ZeLaunchEvent = nullptr;
+  UR_CALL(createSyncPointIfNeeded(
+      CommandType, CommandBuffer, NumSyncPointsInWaitList, SyncPointWaitList,
+      RetSyncPoint, false, ZeEventList, ZeLaunchEvent));
+
+  ze_command_list_handle_t ZeCommandList;
+  UR_CALL(CommandBuffer->chooseCommandList(PreferCopyEngine, &ZeCommandList));
+
+  logger::debug("calling zeCommandListAppendMemoryCopyRegion()");
+  ZE2UR_CALL(zeCommandListAppendMemoryCopyRegion,
+             (ZeCommandList, Dst, &ZeDstRegion, DstPitch, DstSlicePitch, Src,
+              &ZeSrcRegion, SrcPitch, SrcSlicePitch, ZeLaunchEvent,
+              ZeEventList.size(), getPointerFromVector(ZeEventList)));
+
+  return UR_RESULT_SUCCESS;
+}
+
+// Helper function for enqueuing memory fills
+ur_result_t enqueueCommandBufferFillHelper(
+    ur_command_t CommandType, ur_exp_command_buffer_handle_t CommandBuffer,
+    void *Ptr, const void *Pattern, size_t PatternSize, size_t Size,
+    bool PreferCopyEngine, uint32_t NumSyncPointsInWaitList,
+    const ur_exp_command_buffer_sync_point_t *SyncPointWaitList,
+    ur_exp_command_buffer_sync_point_t *RetSyncPoint) {
+  // Pattern size must be a power of two.
+  UR_ASSERT((PatternSize > 0) && ((PatternSize & (PatternSize - 1)) == 0),
+            UR_RESULT_ERROR_INVALID_VALUE);
+
+  // FIXME Why does the event need to be host visible?
+  std::vector<ze_event_handle_t> ZeEventList;
+  ze_event_handle_t ZeLaunchEvent = nullptr;
+  UR_CALL(createSyncPointIfNeeded(
+      CommandType, CommandBuffer, NumSyncPointsInWaitList, SyncPointWaitList,
+      RetSyncPoint, true, ZeEventList, ZeLaunchEvent));
+
+  ze_command_list_handle_t ZeCommandList;
+  UR_CALL(CommandBuffer->chooseCommandList(PreferCopyEngine, &ZeCommandList,
+                                           PatternSize));
+
+  logger::debug("calling zeCommandListAppendMemoryFill()");
+  ZE2UR_CALL(zeCommandListAppendMemoryFill,
+             (ZeCommandList, Ptr, Pattern, PatternSize, Size, ZeLaunchEvent,
+              ZeEventList.size(), getPointerFromVector(ZeEventList)));
+
+  return UR_RESULT_SUCCESS;
+}
+} // namespace
 
 ur_exp_command_buffer_handle_t_::ur_exp_command_buffer_handle_t_(
     ur_context_handle_t Context, ur_device_handle_t Device,
@@ -174,184 +476,11 @@ ur_exp_command_buffer_command_handle_t_::
     urKernelRelease(Kernel);
 }
 
-/// Helper function for calculating work dimensions for kernels
-ur_result_t calculateKernelWorkDimensions(
-    ur_kernel_handle_t Kernel, ur_device_handle_t Device,
-    ze_group_count_t &ZeThreadGroupDimensions, uint32_t (&WG)[3],
-    uint32_t WorkDim, const size_t *GlobalWorkSize,
-    const size_t *LocalWorkSize) {
-
-  UR_ASSERT(GlobalWorkSize, UR_RESULT_ERROR_INVALID_VALUE);
-  // If LocalWorkSize is not provided then Kernel must be provided to query
-  // suggested group size.
-  UR_ASSERT(LocalWorkSize || Kernel, UR_RESULT_ERROR_INVALID_VALUE);
-
-  // New variable needed because GlobalWorkSize parameter might not be of size 3
-  size_t GlobalWorkSize3D[3]{1, 1, 1};
-  std::copy(GlobalWorkSize, GlobalWorkSize + WorkDim, GlobalWorkSize3D);
-
-  if (LocalWorkSize) {
-    WG[0] = ur_cast<uint32_t>(LocalWorkSize[0]);
-    WG[1] = WorkDim >= 2 ? ur_cast<uint32_t>(LocalWorkSize[1]) : 1;
-    WG[2] = WorkDim == 3 ? ur_cast<uint32_t>(LocalWorkSize[2]) : 1;
-  } else {
-    // We can't call to zeKernelSuggestGroupSize if 64-bit GlobalWorkSize3D
-    // values do not fit to 32-bit that the API only supports currently.
-    bool SuggestGroupSize = true;
-    for (int I : {0, 1, 2}) {
-      if (GlobalWorkSize3D[I] > UINT32_MAX) {
-        SuggestGroupSize = false;
-      }
-    }
-    if (SuggestGroupSize) {
-      ZE2UR_CALL(zeKernelSuggestGroupSize,
-                 (Kernel->ZeKernel, GlobalWorkSize3D[0], GlobalWorkSize3D[1],
-                  GlobalWorkSize3D[2], &WG[0], &WG[1], &WG[2]));
-    } else {
-      for (int I : {0, 1, 2}) {
-        // Try to find a I-dimension WG size that the GlobalWorkSize3D[I] is
-        // fully divisable with. Start with the max possible size in
-        // each dimension.
-        uint32_t GroupSize[] = {
-            Device->ZeDeviceComputeProperties->maxGroupSizeX,
-            Device->ZeDeviceComputeProperties->maxGroupSizeY,
-            Device->ZeDeviceComputeProperties->maxGroupSizeZ};
-        GroupSize[I] = (std::min)(size_t(GroupSize[I]), GlobalWorkSize3D[I]);
-        while (GlobalWorkSize3D[I] % GroupSize[I]) {
-          --GroupSize[I];
-        }
-        if (GlobalWorkSize[I] / GroupSize[I] > UINT32_MAX) {
-          logger::debug("calculateKernelWorkDimensions: can't find a WG size "
-                        "suitable for global work size > UINT32_MAX");
-          return UR_RESULT_ERROR_INVALID_WORK_GROUP_SIZE;
-        }
-        WG[I] = GroupSize[I];
-      }
-      logger::debug("calculateKernelWorkDimensions: using computed WG "
-                    "size = {{{}, {}, {}}}",
-                    WG[0], WG[1], WG[2]);
-    }
-  }
-
-  // TODO: assert if sizes do not fit into 32-bit?
-  switch (WorkDim) {
-  case 3:
-    ZeThreadGroupDimensions.groupCountX =
-        ur_cast<uint32_t>(GlobalWorkSize3D[0] / WG[0]);
-    ZeThreadGroupDimensions.groupCountY =
-        ur_cast<uint32_t>(GlobalWorkSize3D[1] / WG[1]);
-    ZeThreadGroupDimensions.groupCountZ =
-        ur_cast<uint32_t>(GlobalWorkSize3D[2] / WG[2]);
-    break;
-  case 2:
-    ZeThreadGroupDimensions.groupCountX =
-        ur_cast<uint32_t>(GlobalWorkSize3D[0] / WG[0]);
-    ZeThreadGroupDimensions.groupCountY =
-        ur_cast<uint32_t>(GlobalWorkSize3D[1] / WG[1]);
-    WG[2] = 1;
-    break;
-  case 1:
-    ZeThreadGroupDimensions.groupCountX =
-        ur_cast<uint32_t>(GlobalWorkSize3D[0] / WG[0]);
-    WG[1] = WG[2] = 1;
-    break;
-
-  default:
-    logger::error("calculateKernelWorkDimensions: unsupported work_dim");
-    return UR_RESULT_ERROR_INVALID_VALUE;
-  }
-
-  // Error handling for non-uniform group size case
-  if (GlobalWorkSize3D[0] !=
-      size_t(ZeThreadGroupDimensions.groupCountX) * WG[0]) {
-    logger::error("calculateKernelWorkDimensions: invalid work_dim. The range "
-                  "is not a multiple of the group size in the 1st dimension");
-    return UR_RESULT_ERROR_INVALID_WORK_GROUP_SIZE;
-  }
-  if (GlobalWorkSize3D[1] !=
-      size_t(ZeThreadGroupDimensions.groupCountY) * WG[1]) {
-    logger::error("calculateKernelWorkDimensions: invalid work_dim. The range "
-                  "is not a multiple of the group size in the 2nd dimension");
-    return UR_RESULT_ERROR_INVALID_WORK_GROUP_SIZE;
-  }
-  if (GlobalWorkSize3D[2] !=
-      size_t(ZeThreadGroupDimensions.groupCountZ) * WG[2]) {
-    logger::error("calculateKernelWorkDimensions: invalid work_dim. The range "
-                  "is not a multiple of the group size in the 3rd dimension");
-    return UR_RESULT_ERROR_INVALID_WORK_GROUP_SIZE;
-  }
-
-  return UR_RESULT_SUCCESS;
-}
-
-/// Helper function for finding the Level Zero events associated with the
-/// commands in a command-buffer, each event is pointed to by a sync-point in
-/// the wait list.
-///
-/// @param[in] CommandBuffer to lookup the L0 events from.
-/// @param[in] NumSyncPointsInWaitList Length of \p SyncPointWaitList.
-/// @param[in] SyncPointWaitList List of sync points in \p CommandBuffer
-/// to find the L0 events for.
-/// @param[out] ZeEventList Return parameter for the L0 events associated with
-/// each sync-point in \p SyncPointWaitList.
-///
-/// @return UR_RESULT_SUCCESS or an error code on failure
-static ur_result_t getEventsFromSyncPoints(
-    const ur_exp_command_buffer_handle_t &CommandBuffer,
-    size_t NumSyncPointsInWaitList,
-    const ur_exp_command_buffer_sync_point_t *SyncPointWaitList,
-    std::vector<ze_event_handle_t> &ZeEventList) {
-  if (!SyncPointWaitList || NumSyncPointsInWaitList == 0)
-    return UR_RESULT_SUCCESS;
-
-  // For each sync-point add associated L0 event to the return list.
-  for (size_t i = 0; i < NumSyncPointsInWaitList; i++) {
-    if (auto EventHandle = CommandBuffer->SyncPoints.find(SyncPointWaitList[i]);
-        EventHandle != CommandBuffer->SyncPoints.end()) {
-      ZeEventList.push_back(EventHandle->second->ZeEvent);
-    } else {
-      return UR_RESULT_ERROR_INVALID_VALUE;
-    }
-  }
-  return UR_RESULT_SUCCESS;
-}
-
-// FIXME Refactor Naming?
-// FIXME Refactor Why do some events need to be host_visible and others don't
-static ur_result_t createSyncPointIfNeeded(
-    ur_command_t CommandType, ur_exp_command_buffer_handle_t CommandBuffer,
-    uint32_t NumSyncPointsInWaitList,
-    const ur_exp_command_buffer_sync_point_t *SyncPointWaitList,
-    ur_exp_command_buffer_sync_point_t *RetSyncPoint, bool host_visible,
-    std::vector<ze_event_handle_t> &ZeEventList,
-    ze_event_handle_t &ZeLaunchEvent) {
-
-  ZeLaunchEvent = nullptr;
-  if (!CommandBuffer->IsInOrderCmdList) {
-    //  std::vector<ze_event_handle_t> ZeEventList;
-    //  ur_event_handle_t LaunchEvent;
-    UR_CALL(getEventsFromSyncPoints(CommandBuffer, NumSyncPointsInWaitList,
-                                    SyncPointWaitList, ZeEventList));
-    ur_event_handle_t LaunchEvent;
-    UR_CALL(EventCreate(CommandBuffer->Context, nullptr, false, host_visible,
-                        &LaunchEvent, false,
-                        !CommandBuffer->IsProfilingEnabled));
-    LaunchEvent->CommandType = CommandType;
-    ZeLaunchEvent = LaunchEvent->ZeEvent;
-
-    // Get sync point and register the event with it.
-    // FIXME Refactor GetNextSyncPoint and RegisterSyncPoint seem redudant. Can
-    // be made into just one function.
-    ur_exp_command_buffer_sync_point_t SyncPoint =
-        CommandBuffer->GetNextSyncPoint();
-    CommandBuffer->RegisterSyncPoint(SyncPoint, LaunchEvent);
-
-    if (RetSyncPoint) {
-      *RetSyncPoint = SyncPoint;
-    }
-  }
-
-  return UR_RESULT_SUCCESS;
+void ur_exp_command_buffer_handle_t_::RegisterSyncPoint(
+    ur_exp_command_buffer_sync_point_t SyncPoint, ur_event_handle_t Event) {
+  SyncPoints[SyncPoint] = Event;
+  NextSyncPoint++;
+  ZeEventsList.push_back(Event->ZeEvent);
 }
 
 ur_result_t ur_exp_command_buffer_handle_t_::chooseCommandList(
@@ -395,133 +524,39 @@ ur_result_t ur_exp_command_buffer_handle_t_::chooseCommandList(
   return UR_RESULT_SUCCESS;
 }
 
-template <typename T> static T *getPointerFromVector(std::vector<T> &V) {
-  return V.size() == 0 ? nullptr : V.data();
-}
-
-// Shared by all memory read/write/copy PI interfaces.
-// Helper function for common code when enqueuing memory operations to a command
-// buffer.
-static ur_result_t enqueueCommandBufferMemCopyHelper(
-    ur_command_t CommandType, ur_exp_command_buffer_handle_t CommandBuffer,
-    void *Dst, const void *Src, size_t Size, bool PreferCopyEngine,
-    uint32_t NumSyncPointsInWaitList,
-    const ur_exp_command_buffer_sync_point_t *SyncPointWaitList,
-    ur_exp_command_buffer_sync_point_t *RetSyncPoint) {
-
-  // FIXME Why doesn't the event need to be host visible
-  std::vector<ze_event_handle_t> ZeEventList;
-  ze_event_handle_t ZeLaunchEvent = nullptr;
-  UR_CALL(createSyncPointIfNeeded(
-      CommandType, CommandBuffer, NumSyncPointsInWaitList, SyncPointWaitList,
-      RetSyncPoint, false, ZeEventList, ZeLaunchEvent));
-
-  ze_command_list_handle_t ZeCommandList;
-  UR_CALL(CommandBuffer->chooseCommandList(PreferCopyEngine, &ZeCommandList));
-
-  logger::debug("calling zeCommandListAppendMemoryCopy()");
-  ZE2UR_CALL(zeCommandListAppendMemoryCopy,
-             (ZeCommandList, Dst, Src, Size, ZeLaunchEvent, ZeEventList.size(),
-              getPointerFromVector(ZeEventList)));
-
+ur_result_t ur_exp_command_buffer_handle_t_::getFence(
+    ze_command_queue_handle_t &ZeCommandQueue, ze_fence_handle_t &ZeFence) {
+  // If we already have created a fence for this queue, first reset then reuse
+  // it, otherwise create a new fence.
+  //  ZeFence = this->ZeActiveFence;
+  auto ZeWorkloadFenceForQueue = this->ZeFencesMap.find(ZeCommandQueue);
+  if (ZeWorkloadFenceForQueue == this->ZeFencesMap.end()) {
+    ZeStruct<ze_fence_desc_t> ZeFenceDesc;
+    ZE2UR_CALL(zeFenceCreate, (ZeCommandQueue, &ZeFenceDesc, &ZeFence));
+    this->ZeFencesMap.insert({{ZeCommandQueue, ZeFence}});
+  } else {
+    ZeFence = ZeWorkloadFenceForQueue->second;
+    ZE2UR_CALL(zeFenceReset, (ZeFence));
+  }
+  this->ZeActiveFence = ZeFence;
   return UR_RESULT_SUCCESS;
 }
 
-// Helper function for common code when enqueuing rectangular memory operations
-// to a command buffer.
-static ur_result_t enqueueCommandBufferMemCopyRectHelper(
-    ur_command_t CommandType, ur_exp_command_buffer_handle_t CommandBuffer,
-    void *Dst, const void *Src, ur_rect_offset_t SrcOrigin,
-    ur_rect_offset_t DstOrigin, ur_rect_region_t Region, size_t SrcRowPitch,
-    size_t DstRowPitch, size_t SrcSlicePitch, size_t DstSlicePitch,
-    bool PreferCopyEngine, uint32_t NumSyncPointsInWaitList,
-    const ur_exp_command_buffer_sync_point_t *SyncPointWaitList,
-    ur_exp_command_buffer_sync_point_t *RetSyncPoint) {
-
-  uint32_t SrcOriginX = ur_cast<uint32_t>(SrcOrigin.x);
-  uint32_t SrcOriginY = ur_cast<uint32_t>(SrcOrigin.y);
-  uint32_t SrcOriginZ = ur_cast<uint32_t>(SrcOrigin.z);
-
-  uint32_t SrcPitch = SrcRowPitch;
-  if (SrcPitch == 0)
-    SrcPitch = ur_cast<uint32_t>(Region.width);
-
-  if (SrcSlicePitch == 0)
-    SrcSlicePitch = ur_cast<uint32_t>(Region.height) * SrcPitch;
-
-  uint32_t DstOriginX = ur_cast<uint32_t>(DstOrigin.x);
-  uint32_t DstOriginY = ur_cast<uint32_t>(DstOrigin.y);
-  uint32_t DstOriginZ = ur_cast<uint32_t>(DstOrigin.z);
-
-  uint32_t DstPitch = DstRowPitch;
-  if (DstPitch == 0)
-    DstPitch = ur_cast<uint32_t>(Region.width);
-
-  if (DstSlicePitch == 0)
-    DstSlicePitch = ur_cast<uint32_t>(Region.height) * DstPitch;
-
-  uint32_t Width = ur_cast<uint32_t>(Region.width);
-  uint32_t Height = ur_cast<uint32_t>(Region.height);
-  uint32_t Depth = ur_cast<uint32_t>(Region.depth);
-
-  const ze_copy_region_t ZeSrcRegion = {SrcOriginX, SrcOriginY, SrcOriginZ,
-                                        Width,      Height,     Depth};
-  const ze_copy_region_t ZeDstRegion = {DstOriginX, DstOriginY, DstOriginZ,
-                                        Width,      Height,     Depth};
-
-  // FIXME Why doesn't the event need to be host visible
-  std::vector<ze_event_handle_t> ZeEventList;
-  ze_event_handle_t ZeLaunchEvent = nullptr;
-  UR_CALL(createSyncPointIfNeeded(
-      CommandType, CommandBuffer, NumSyncPointsInWaitList, SyncPointWaitList,
-      RetSyncPoint, false, ZeEventList, ZeLaunchEvent));
-
-  ze_command_list_handle_t ZeCommandList;
-  UR_CALL(CommandBuffer->chooseCommandList(PreferCopyEngine, &ZeCommandList));
-
-  logger::debug("calling zeCommandListAppendMemoryCopyRegion()");
-  ZE2UR_CALL(zeCommandListAppendMemoryCopyRegion,
-             (ZeCommandList, Dst, &ZeDstRegion, DstPitch, DstSlicePitch, Src,
-              &ZeSrcRegion, SrcPitch, SrcSlicePitch, ZeLaunchEvent,
-              ZeEventList.size(), getPointerFromVector(ZeEventList)));
-
+ur_result_t ur_exp_command_buffer_handle_t_::getZeCommandQueue(
+    ur_queue_handle_t Queue, bool UseCopyEngine,
+    ze_command_queue_handle_t &ZeCommandQueue) {
+  // Use compute engine rather than copy engine
+  auto &QGroup = Queue->getQueueGroup(UseCopyEngine);
+  uint32_t QueueGroupOrdinal;
+  ZeCommandQueue = QGroup.getZeQueue(&QueueGroupOrdinal);
   return UR_RESULT_SUCCESS;
 }
 
-// Helper function for enqueuing memory fills
-static ur_result_t enqueueCommandBufferFillHelper(
-    ur_command_t CommandType, ur_exp_command_buffer_handle_t CommandBuffer,
-    void *Ptr, const void *Pattern, size_t PatternSize, size_t Size,
-    bool PreferCopyEngine, uint32_t NumSyncPointsInWaitList,
-    const ur_exp_command_buffer_sync_point_t *SyncPointWaitList,
-    ur_exp_command_buffer_sync_point_t *RetSyncPoint) {
-  // Pattern size must be a power of two.
-  UR_ASSERT((PatternSize > 0) && ((PatternSize & (PatternSize - 1)) == 0),
-            UR_RESULT_ERROR_INVALID_VALUE);
-
-  // FIXME Why does the event need to be host visible?
-  std::vector<ze_event_handle_t> ZeEventList;
-  ze_event_handle_t ZeLaunchEvent = nullptr;
-  UR_CALL(createSyncPointIfNeeded(
-      CommandType, CommandBuffer, NumSyncPointsInWaitList, SyncPointWaitList,
-      RetSyncPoint, true, ZeEventList, ZeLaunchEvent));
-
-  ze_command_list_handle_t ZeCommandList;
-  UR_CALL(CommandBuffer->chooseCommandList(PreferCopyEngine, &ZeCommandList,
-                                           PatternSize));
-
-  logger::debug("calling zeCommandListAppendMemoryFill()");
-  ZE2UR_CALL(zeCommandListAppendMemoryFill,
-             (ZeCommandList, Ptr, Pattern, PatternSize, Size, ZeLaunchEvent,
-              ZeEventList.size(), getPointerFromVector(ZeEventList)));
-
-  return UR_RESULT_SUCCESS;
-}
-
-static ur_result_t
-createMainCommandList(ur_context_handle_t Context, ur_device_handle_t Device,
-                      bool IsInOrder, bool isUpdatable, bool isCopy,
-                      ze_command_list_handle_t &CommandList) {
+namespace {
+ur_result_t createMainCommandList(ur_context_handle_t Context,
+                                  ur_device_handle_t Device, bool IsInOrder,
+                                  bool isUpdatable, bool isCopy,
+                                  ze_command_list_handle_t &CommandList) {
 
   auto type = isCopy ? ur_device_handle_t_::queue_group_info_t::type::MainCopy
                      : ur_device_handle_t_::queue_group_info_t::type::Compute;
@@ -550,10 +585,9 @@ createMainCommandList(ur_context_handle_t Context, ur_device_handle_t Device,
   return UR_RESULT_SUCCESS;
 }
 
-static ur_result_t
-appendPreconditionEvents(ze_command_list_handle_t CommandList,
-                         ur_event_handle_t WaitEvent,
-                         ur_event_handle_t AllResetEvent) {
+ur_result_t appendPreconditionEvents(ze_command_list_handle_t CommandList,
+                                     ur_event_handle_t WaitEvent,
+                                     ur_event_handle_t AllResetEvent) {
   std::vector<ze_event_handle_t> PrecondEvents = {WaitEvent->ZeEvent,
                                                   AllResetEvent->ZeEvent};
   ZE2UR_CALL(
@@ -562,15 +596,16 @@ appendPreconditionEvents(ze_command_list_handle_t CommandList,
   return UR_RESULT_SUCCESS;
 }
 
-static bool
-enableInOrder(ur_context_handle_t Context,
-              const ur_exp_command_buffer_desc_t *CommandBufferDesc) {
+bool enableInOrder(ur_context_handle_t Context,
+                   const ur_exp_command_buffer_desc_t *CommandBufferDesc) {
   // In-order command-lists are not available in old driver version.
   bool CompatibleDriver = IsDriverVersionNewerOrSimilar(Context, 1, 3, 28454);
   return CompatibleDriver
              ? (CommandBufferDesc ? CommandBufferDesc->isInOrder : false)
              : false;
 }
+} // namespace
+
 UR_APIEXPORT ur_result_t UR_APICALL
 urCommandBufferCreateExp(ur_context_handle_t Context, ur_device_handle_t Device,
                          const ur_exp_command_buffer_desc_t *CommandBufferDesc,
@@ -647,13 +682,6 @@ urCommandBufferReleaseExp(ur_exp_command_buffer_handle_t CommandBuffer) {
   return UR_RESULT_SUCCESS;
 }
 
-void ur_exp_command_buffer_handle_t_::RegisterSyncPoint(
-    ur_exp_command_buffer_sync_point_t SyncPoint, ur_event_handle_t Event) {
-  SyncPoints[SyncPoint] = Event;
-  NextSyncPoint++;
-  ZeEventsList.push_back(Event->ZeEvent);
-}
-
 UR_APIEXPORT ur_result_t UR_APICALL
 urCommandBufferFinalizeExp(ur_exp_command_buffer_handle_t CommandBuffer) {
   UR_ASSERT(CommandBuffer, UR_RESULT_ERROR_INVALID_NULL_POINTER);
@@ -698,10 +726,10 @@ urCommandBufferFinalizeExp(ur_exp_command_buffer_handle_t CommandBuffer) {
   return UR_RESULT_SUCCESS;
 }
 
-static ur_result_t
-setKernelGlobalOffset(ur_exp_command_buffer_handle_t CommandBuffer,
-                      ur_kernel_handle_t Kernel,
-                      const size_t *GlobalWorkOffset) {
+namespace {
+ur_result_t setKernelGlobalOffset(ur_exp_command_buffer_handle_t CommandBuffer,
+                                  ur_kernel_handle_t Kernel,
+                                  const size_t *GlobalWorkOffset) {
 
   if (!CommandBuffer->Context->getPlatform()
            ->ZeDriverGlobalOffsetExtensionFound) {
@@ -716,7 +744,7 @@ setKernelGlobalOffset(ur_exp_command_buffer_handle_t CommandBuffer,
   return UR_RESULT_SUCCESS;
 }
 
-static ur_result_t
+ur_result_t
 setKernelPendingArguments(ur_exp_command_buffer_handle_t CommandBuffer,
                           ur_kernel_handle_t Kernel) {
 
@@ -737,7 +765,7 @@ setKernelPendingArguments(ur_exp_command_buffer_handle_t CommandBuffer,
   return UR_RESULT_SUCCESS;
 }
 
-static ur_result_t
+ur_result_t
 createCommandHandle(ur_exp_command_buffer_handle_t CommandBuffer,
                     ur_kernel_handle_t Kernel, uint32_t WorkDim,
                     const size_t *LocalWorkSize,
@@ -774,6 +802,8 @@ createCommandHandle(ur_exp_command_buffer_handle_t CommandBuffer,
 
   return UR_RESULT_SUCCESS;
 }
+} // namespace
+
 UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendKernelLaunchExp(
     ur_exp_command_buffer_handle_t CommandBuffer, ur_kernel_handle_t Kernel,
     uint32_t WorkDim, const size_t *GlobalWorkOffset,
@@ -1140,40 +1170,12 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendUSMFillExp(
       SyncPoint);
 }
 
-ur_result_t ur_exp_command_buffer_handle_t_::getFence(
-    ze_command_queue_handle_t &ZeCommandQueue, ze_fence_handle_t &ZeFence) {
-  // If we already have created a fence for this queue, first reset then reuse
-  // it, otherwise create a new fence.
-  //  ZeFence = this->ZeActiveFence;
-  auto ZeWorkloadFenceForQueue = this->ZeFencesMap.find(ZeCommandQueue);
-  if (ZeWorkloadFenceForQueue == this->ZeFencesMap.end()) {
-    ZeStruct<ze_fence_desc_t> ZeFenceDesc;
-    ZE2UR_CALL(zeFenceCreate, (ZeCommandQueue, &ZeFenceDesc, &ZeFence));
-    this->ZeFencesMap.insert({{ZeCommandQueue, ZeFence}});
-  } else {
-    ZeFence = ZeWorkloadFenceForQueue->second;
-    ZE2UR_CALL(zeFenceReset, (ZeFence));
-  }
-  this->ZeActiveFence = ZeFence;
-  return UR_RESULT_SUCCESS;
-}
-
-ur_result_t ur_exp_command_buffer_handle_t_::getZeCommandQueue(
-    ur_queue_handle_t Queue, bool UseCopyEngine,
-    ze_command_queue_handle_t &ZeCommandQueue) {
-  // Use compute engine rather than copy engine
-  auto &QGroup = Queue->getQueueGroup(UseCopyEngine);
-  uint32_t QueueGroupOrdinal;
-  ZeCommandQueue = QGroup.getZeQueue(&QueueGroupOrdinal);
-  return UR_RESULT_SUCCESS;
-}
-
+namespace {
 // FIXME Refactor Document
-static ur_result_t
-waitForDependencies(ur_exp_command_buffer_handle_t CommandBuffer,
-                    ur_queue_handle_t Queue, uint32_t NumEventsInWaitList,
-                    const ur_event_handle_t *EventWaitList) {
-  _ur_ze_event_list_t TmpWaitList;
+ur_result_t waitForDependencies(ur_exp_command_buffer_handle_t CommandBuffer,
+                                ur_queue_handle_t Queue,
+                                uint32_t NumEventsInWaitList,
+                                const ur_event_handle_t *EventWaitList) {
   const bool UseCopyEngine = false;
   bool MustSignalWaitEvent = true;
   if (NumEventsInWaitList) {
@@ -1213,10 +1215,10 @@ waitForDependencies(ur_exp_command_buffer_handle_t CommandBuffer,
 }
 
 // FIXME Refactor Document
-static ur_result_t createUserEvent(ur_exp_command_buffer_handle_t CommandBuffer,
-                                   ur_queue_handle_t Queue,
-                                   ur_command_list_ptr_t SignalCommandList,
-                                   ur_event_handle_t &Event) {
+ur_result_t createUserEvent(ur_exp_command_buffer_handle_t CommandBuffer,
+                            ur_queue_handle_t Queue,
+                            ur_command_list_ptr_t SignalCommandList,
+                            ur_event_handle_t &Event) {
   // Execution event for this enqueue of the UR command-buffer
   ur_event_handle_t RetEvent{};
 
@@ -1256,6 +1258,7 @@ static ur_result_t createUserEvent(ur_exp_command_buffer_handle_t CommandBuffer,
 
   return UR_RESULT_SUCCESS;
 }
+} // namespace
 
 UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferEnqueueExp(
     ur_exp_command_buffer_handle_t CommandBuffer, ur_queue_handle_t UrQueue,
@@ -1338,7 +1341,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferReleaseCommandExp(
   return UR_RESULT_SUCCESS;
 }
 
-static ur_result_t validateCommandDesc(
+namespace {
+ur_result_t validateCommandDesc(
     ur_exp_command_buffer_command_handle_t Command,
     const ur_exp_command_buffer_update_kernel_launch_desc_t *CommandDesc) {
 
@@ -1408,7 +1412,7 @@ static ur_result_t validateCommandDesc(
   return UR_RESULT_SUCCESS;
 }
 
-static ur_result_t updateKernelCommand(
+ur_result_t updateKernelCommand(
     ur_exp_command_buffer_command_handle_t Command,
     const ur_exp_command_buffer_update_kernel_launch_desc_t *CommandDesc) {
 
@@ -1637,6 +1641,7 @@ static ur_result_t updateKernelCommand(
 
   return UR_RESULT_SUCCESS;
 }
+} // namespace
 
 UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferUpdateKernelLaunchExp(
     ur_exp_command_buffer_command_handle_t Command,

--- a/source/adapters/level_zero/command_buffer.cpp
+++ b/source/adapters/level_zero/command_buffer.cpp
@@ -726,8 +726,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendKernelLaunchExp(
     const ur_exp_command_buffer_sync_point_t *SyncPointWaitList,
     ur_exp_command_buffer_sync_point_t *RetSyncPoint,
     ur_exp_command_buffer_command_handle_t *Command) {
-  UR_ASSERT(CommandBuffer && Kernel && Kernel->Program,
-            UR_RESULT_ERROR_INVALID_NULL_POINTER);
+  UR_ASSERT(Kernel->Program, UR_RESULT_ERROR_INVALID_NULL_POINTER);
   // Lock automatically releases when this goes out of scope.
   std::scoped_lock<ur_shared_mutex, ur_shared_mutex, ur_shared_mutex> Lock(
       Kernel->Mutex, Kernel->Program->Mutex, CommandBuffer->Mutex);
@@ -1338,9 +1337,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferReleaseCommandExp(
 UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferUpdateKernelLaunchExp(
     ur_exp_command_buffer_command_handle_t Command,
     const ur_exp_command_buffer_update_kernel_launch_desc_t *CommandDesc) {
-  UR_ASSERT(Command, UR_RESULT_ERROR_INVALID_NULL_HANDLE);
   UR_ASSERT(Command->Kernel, UR_RESULT_ERROR_INVALID_NULL_HANDLE);
-  UR_ASSERT(CommandDesc, UR_RESULT_ERROR_INVALID_NULL_POINTER);
   UR_ASSERT(CommandDesc->newWorkDim <= 3,
             UR_RESULT_ERROR_INVALID_WORK_DIMENSION);
 

--- a/source/adapters/level_zero/command_buffer.cpp
+++ b/source/adapters/level_zero/command_buffer.cpp
@@ -318,31 +318,37 @@ static ur_result_t getEventsFromSyncPoints(
 
 // FIXME Refactor Naming?
 // FIXME Refactor Why do some events need to be host_visible and others don't
-static ur_result_t
-createSyncPoint(ur_command_t CommandType,
-                ur_exp_command_buffer_handle_t CommandBuffer,
-                uint32_t NumSyncPointsInWaitList,
-                const ur_exp_command_buffer_sync_point_t *SyncPointWaitList,
-                ur_exp_command_buffer_sync_point_t *RetSyncPoint,
-                bool host_visible, std::vector<ze_event_handle_t> &ZeEventList,
-                ur_event_handle_t &LaunchEvent) {
-  //  std::vector<ze_event_handle_t> ZeEventList;
-  //  ur_event_handle_t LaunchEvent;
-  UR_CALL(getEventsFromSyncPoints(CommandBuffer, NumSyncPointsInWaitList,
-                                  SyncPointWaitList, ZeEventList));
-  UR_CALL(EventCreate(CommandBuffer->Context, nullptr, false, host_visible,
-                      &LaunchEvent, false, !CommandBuffer->IsProfilingEnabled));
-  LaunchEvent->CommandType = CommandType;
+static ur_result_t createSyncPointIfNeeded(
+    ur_command_t CommandType, ur_exp_command_buffer_handle_t CommandBuffer,
+    uint32_t NumSyncPointsInWaitList,
+    const ur_exp_command_buffer_sync_point_t *SyncPointWaitList,
+    ur_exp_command_buffer_sync_point_t *RetSyncPoint, bool host_visible,
+    std::vector<ze_event_handle_t> &ZeEventList,
+    ze_event_handle_t &ZeLaunchEvent) {
 
-  // Get sync point and register the event with it.
-  // FIXME Refactor GetNextSyncPoint and RegisterSyncPoint seem redudant. Can be
-  // made into just one function.
-  ur_exp_command_buffer_sync_point_t SyncPoint =
-      CommandBuffer->GetNextSyncPoint();
-  CommandBuffer->RegisterSyncPoint(SyncPoint, LaunchEvent);
+  ZeLaunchEvent = nullptr;
+  if (!CommandBuffer->IsInOrderCmdList) {
+    //  std::vector<ze_event_handle_t> ZeEventList;
+    //  ur_event_handle_t LaunchEvent;
+    UR_CALL(getEventsFromSyncPoints(CommandBuffer, NumSyncPointsInWaitList,
+                                    SyncPointWaitList, ZeEventList));
+    ur_event_handle_t LaunchEvent;
+    UR_CALL(EventCreate(CommandBuffer->Context, nullptr, false, host_visible,
+                        &LaunchEvent, false,
+                        !CommandBuffer->IsProfilingEnabled));
+    LaunchEvent->CommandType = CommandType;
+    ZeLaunchEvent = LaunchEvent->ZeEvent;
 
-  if (RetSyncPoint) {
-    *RetSyncPoint = SyncPoint;
+    // Get sync point and register the event with it.
+    // FIXME Refactor GetNextSyncPoint and RegisterSyncPoint seem redudant. Can
+    // be made into just one function.
+    ur_exp_command_buffer_sync_point_t SyncPoint =
+        CommandBuffer->GetNextSyncPoint();
+    CommandBuffer->RegisterSyncPoint(SyncPoint, LaunchEvent);
+
+    if (RetSyncPoint) {
+      *RetSyncPoint = SyncPoint;
+    }
   }
 
   return UR_RESULT_SUCCESS;
@@ -352,7 +358,7 @@ ur_result_t ur_exp_command_buffer_handle_t_::chooseCommandList(
     bool PreferCopyEngine, ze_command_list_handle_t *ZeCommandList) {
   // If the copy engine available, the command is enqueued in the
   // ZeCopyCommandList.
-  if (PreferCopyEngine && this->UseCopyEngine()) {
+  if (PreferCopyEngine && this->UseCopyEngine() && !this->IsInOrderCmdList) {
     // We indicate that the ZeCopyCommandList contains commands to be
     // submitted.
     this->MCopyCommandListEmpty = false;
@@ -386,6 +392,11 @@ ur_result_t ur_exp_command_buffer_handle_t_::chooseCommandList(
         UR_RESULT_ERROR_INVALID_VALUE);
   }
   UR_CALL(chooseCommandList(PreferCopyEngine, ZeCommandList));
+  return UR_RESULT_SUCCESS;
+}
+
+template <typename T> static T *getPointerFromVector(std::vector<T> &V) {
+  return V.size() == 0 ? nullptr : V.data();
 }
 
 // Shared by all memory read/write/copy PI interfaces.
@@ -397,31 +408,22 @@ static ur_result_t enqueueCommandBufferMemCopyHelper(
     uint32_t NumSyncPointsInWaitList,
     const ur_exp_command_buffer_sync_point_t *SyncPointWaitList,
     ur_exp_command_buffer_sync_point_t *RetSyncPoint) {
-  if (CommandBuffer->IsInOrderCmdList) {
-    ZE2UR_CALL(zeCommandListAppendMemoryCopy,
-               (CommandBuffer->ZeComputeCommandList, Dst, Src, Size, nullptr, 0,
-                nullptr));
 
-    logger::debug("calling zeCommandListAppendMemoryCopy()");
-  } else {
-    // FIXME Why doesn't the event need to be host visible
-    std::vector<ze_event_handle_t> ZeEventList;
-    ur_event_handle_t LaunchEvent = nullptr;
-    UR_CALL(createSyncPoint(CommandType, CommandBuffer, NumSyncPointsInWaitList,
-                            SyncPointWaitList, RetSyncPoint, false, ZeEventList,
-                            LaunchEvent));
+  // FIXME Why doesn't the event need to be host visible
+  std::vector<ze_event_handle_t> ZeEventList;
+  ze_event_handle_t ZeLaunchEvent = nullptr;
+  UR_CALL(createSyncPointIfNeeded(
+      CommandType, CommandBuffer, NumSyncPointsInWaitList, SyncPointWaitList,
+      RetSyncPoint, false, ZeEventList, ZeLaunchEvent));
 
-    ze_command_list_handle_t ZeCommandList;
-    UR_CALL(CommandBuffer->chooseCommandList(PreferCopyEngine, &ZeCommandList));
+  ze_command_list_handle_t ZeCommandList;
+  UR_CALL(CommandBuffer->chooseCommandList(PreferCopyEngine, &ZeCommandList));
 
-    ZE2UR_CALL(zeCommandListAppendMemoryCopy,
-               (ZeCommandList, Dst, Src, Size, LaunchEvent->ZeEvent,
-                ZeEventList.size(), ZeEventList.data()));
+  logger::debug("calling zeCommandListAppendMemoryCopy()");
+  ZE2UR_CALL(zeCommandListAppendMemoryCopy,
+             (ZeCommandList, Dst, Src, Size, ZeLaunchEvent, ZeEventList.size(),
+              getPointerFromVector(ZeEventList)));
 
-    logger::debug("calling zeCommandListAppendMemoryCopy() with"
-                  "  ZeEvent {}",
-                  ur_cast<std::uintptr_t>(LaunchEvent->ZeEvent));
-  }
   return UR_RESULT_SUCCESS;
 }
 
@@ -467,33 +469,21 @@ static ur_result_t enqueueCommandBufferMemCopyRectHelper(
   const ze_copy_region_t ZeDstRegion = {DstOriginX, DstOriginY, DstOriginZ,
                                         Width,      Height,     Depth};
 
-  if (CommandBuffer->IsInOrderCmdList) {
-    ZE2UR_CALL(zeCommandListAppendMemoryCopyRegion,
-               (CommandBuffer->ZeComputeCommandList, Dst, &ZeDstRegion,
-                DstPitch, DstSlicePitch, Src, &ZeSrcRegion, SrcPitch,
-                SrcSlicePitch, nullptr, 0, nullptr));
+  // FIXME Why doesn't the event need to be host visible
+  std::vector<ze_event_handle_t> ZeEventList;
+  ze_event_handle_t ZeLaunchEvent = nullptr;
+  UR_CALL(createSyncPointIfNeeded(
+      CommandType, CommandBuffer, NumSyncPointsInWaitList, SyncPointWaitList,
+      RetSyncPoint, false, ZeEventList, ZeLaunchEvent));
 
-    logger::debug("calling zeCommandListAppendMemoryCopyRegion()");
-  } else {
-    // FIXME Why doesn't the event need to be host visible
-    std::vector<ze_event_handle_t> ZeEventList;
-    ur_event_handle_t LaunchEvent;
-    UR_CALL(createSyncPoint(CommandType, CommandBuffer, NumSyncPointsInWaitList,
-                            SyncPointWaitList, RetSyncPoint, false, ZeEventList,
-                            LaunchEvent));
+  ze_command_list_handle_t ZeCommandList;
+  UR_CALL(CommandBuffer->chooseCommandList(PreferCopyEngine, &ZeCommandList));
 
-    ze_command_list_handle_t ZeCommandList;
-    UR_CALL(CommandBuffer->chooseCommandList(PreferCopyEngine, &ZeCommandList));
-
-    ZE2UR_CALL(zeCommandListAppendMemoryCopyRegion,
-               (ZeCommandList, Dst, &ZeDstRegion, DstPitch, DstSlicePitch, Src,
-                &ZeSrcRegion, SrcPitch, SrcSlicePitch, LaunchEvent->ZeEvent,
-                ZeEventList.size(), ZeEventList.data()));
-
-    logger::debug("calling zeCommandListAppendMemoryCopyRegion() with"
-                  "  ZeEvent {}",
-                  ur_cast<std::uintptr_t>(LaunchEvent->ZeEvent));
-  }
+  logger::debug("calling zeCommandListAppendMemoryCopyRegion()");
+  ZE2UR_CALL(zeCommandListAppendMemoryCopyRegion,
+             (ZeCommandList, Dst, &ZeDstRegion, DstPitch, DstSlicePitch, Src,
+              &ZeSrcRegion, SrcPitch, SrcSlicePitch, ZeLaunchEvent,
+              ZeEventList.size(), getPointerFromVector(ZeEventList)));
 
   return UR_RESULT_SUCCESS;
 }
@@ -509,32 +499,21 @@ static ur_result_t enqueueCommandBufferFillHelper(
   UR_ASSERT((PatternSize > 0) && ((PatternSize & (PatternSize - 1)) == 0),
             UR_RESULT_ERROR_INVALID_VALUE);
 
+  // FIXME Why does the event need to be host visible?
+  std::vector<ze_event_handle_t> ZeEventList;
+  ze_event_handle_t ZeLaunchEvent = nullptr;
+  UR_CALL(createSyncPointIfNeeded(
+      CommandType, CommandBuffer, NumSyncPointsInWaitList, SyncPointWaitList,
+      RetSyncPoint, true, ZeEventList, ZeLaunchEvent));
+
   ze_command_list_handle_t ZeCommandList;
   UR_CALL(CommandBuffer->chooseCommandList(PreferCopyEngine, &ZeCommandList,
                                            PatternSize));
 
-  if (CommandBuffer->IsInOrderCmdList) {
-    ZE2UR_CALL(zeCommandListAppendMemoryFill,
-               (CommandBuffer->ZeComputeCommandList, Ptr, Pattern, PatternSize,
-                Size, nullptr, 0, nullptr));
-
-    logger::debug("calling zeCommandListAppendMemoryFill()");
-  } else {
-    // FIXME Why does the event need to be host visible?
-    std::vector<ze_event_handle_t> ZeEventList;
-    ur_event_handle_t LaunchEvent;
-    UR_CALL(createSyncPoint(CommandType, CommandBuffer, NumSyncPointsInWaitList,
-                            SyncPointWaitList, RetSyncPoint, true, ZeEventList,
-                            LaunchEvent));
-
-    ZE2UR_CALL(zeCommandListAppendMemoryFill,
-               (ZeCommandList, Ptr, Pattern, PatternSize, Size,
-                LaunchEvent->ZeEvent, ZeEventList.size(), ZeEventList.data()));
-
-    logger::debug("calling zeCommandListAppendMemoryFill() with"
-                  "  ZeEvent {}",
-                  ur_cast<std::uintptr_t>(LaunchEvent->ZeEvent));
-  }
+  logger::debug("calling zeCommandListAppendMemoryFill()");
+  ZE2UR_CALL(zeCommandListAppendMemoryFill,
+             (ZeCommandList, Ptr, Pattern, PatternSize, Size, ZeLaunchEvent,
+              ZeEventList.size(), getPointerFromVector(ZeEventList)));
 
   return UR_RESULT_SUCCESS;
 }
@@ -580,6 +559,7 @@ appendPreconditionEvents(ze_command_list_handle_t CommandList,
   ZE2UR_CALL(
       zeCommandListAppendBarrier,
       (CommandList, nullptr, PrecondEvents.size(), PrecondEvents.data()));
+  return UR_RESULT_SUCCESS;
 }
 
 static bool
@@ -838,28 +818,17 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendKernelLaunchExp(
                                 *Command));
   }
 
-  if (CommandBuffer->IsInOrderCmdList) {
-    ZE2UR_CALL(zeCommandListAppendLaunchKernel,
-               (CommandBuffer->ZeComputeCommandList, Kernel->ZeKernel,
-                &ZeThreadGroupDimensions, nullptr, 0, nullptr));
+  std::vector<ze_event_handle_t> ZeEventList;
+  ze_event_handle_t ZeLaunchEvent = nullptr;
+  UR_CALL(createSyncPointIfNeeded(
+      UR_COMMAND_KERNEL_LAUNCH, CommandBuffer, NumSyncPointsInWaitList,
+      SyncPointWaitList, RetSyncPoint, false, ZeEventList, ZeLaunchEvent));
 
-    logger::debug("calling zeCommandListAppendLaunchKernel()");
-  } else {
-    std::vector<ze_event_handle_t> ZeEventList;
-    ur_event_handle_t LaunchEvent;
-    UR_CALL(createSyncPoint(UR_COMMAND_KERNEL_LAUNCH, CommandBuffer,
-                            NumSyncPointsInWaitList, SyncPointWaitList,
-                            RetSyncPoint, false, ZeEventList, LaunchEvent));
-
-    ZE2UR_CALL(zeCommandListAppendLaunchKernel,
-               (CommandBuffer->ZeComputeCommandList, Kernel->ZeKernel,
-                &ZeThreadGroupDimensions, LaunchEvent->ZeEvent,
-                ZeEventList.size(), ZeEventList.data()));
-
-    logger::debug("calling zeCommandListAppendLaunchKernel() with"
-                  "  ZeEvent {}",
-                  ur_cast<std::uintptr_t>(LaunchEvent->ZeEvent));
-  }
+  logger::debug("calling zeCommandListAppendLaunchKernel()");
+  ZE2UR_CALL(zeCommandListAppendLaunchKernel,
+             (CommandBuffer->ZeComputeCommandList, Kernel->ZeKernel,
+              &ZeThreadGroupDimensions, ZeLaunchEvent, ZeEventList.size(),
+              getPointerFromVector(ZeEventList)));
 
   return UR_RESULT_SUCCESS;
 }
@@ -1046,10 +1015,10 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendUSMPrefetchExp(
   } else {
     // FIXME Why does the event need to be host visible?
     std::vector<ze_event_handle_t> ZeEventList;
-    ur_event_handle_t LaunchEvent;
-    UR_CALL(createSyncPoint(UR_COMMAND_USM_PREFETCH, CommandBuffer,
-                            NumSyncPointsInWaitList, SyncPointWaitList,
-                            RetSyncPoint, true, ZeEventList, LaunchEvent));
+    ze_event_handle_t ZeLaunchEvent = nullptr;
+    UR_CALL(createSyncPointIfNeeded(
+        UR_COMMAND_USM_PREFETCH, CommandBuffer, NumSyncPointsInWaitList,
+        SyncPointWaitList, RetSyncPoint, true, ZeEventList, ZeLaunchEvent));
 
     if (NumSyncPointsInWaitList) {
       ZE2UR_CALL(zeCommandListAppendWaitOnEvents,
@@ -1065,7 +1034,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendUSMPrefetchExp(
     // Level Zero does not have a completion "event" with the prefetch API,
     // so manually add command to signal our event.
     ZE2UR_CALL(zeCommandListAppendSignalEvent,
-               (CommandBuffer->ZeComputeCommandList, LaunchEvent->ZeEvent));
+               (CommandBuffer->ZeComputeCommandList, ZeLaunchEvent));
   }
 
   return UR_RESULT_SUCCESS;
@@ -1110,10 +1079,10 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendUSMAdviseExp(
   } else {
     // FIMXE Why does the event need to be host visible?
     std::vector<ze_event_handle_t> ZeEventList;
-    ur_event_handle_t LaunchEvent;
-    UR_CALL(createSyncPoint(UR_COMMAND_USM_ADVISE, CommandBuffer,
-                            NumSyncPointsInWaitList, SyncPointWaitList,
-                            RetSyncPoint, true, ZeEventList, LaunchEvent));
+    ze_event_handle_t ZeLaunchEvent = nullptr;
+    UR_CALL(createSyncPointIfNeeded(
+        UR_COMMAND_USM_ADVISE, CommandBuffer, NumSyncPointsInWaitList,
+        SyncPointWaitList, RetSyncPoint, true, ZeEventList, ZeLaunchEvent));
 
     if (NumSyncPointsInWaitList) {
       ZE2UR_CALL(zeCommandListAppendWaitOnEvents,
@@ -1128,7 +1097,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendUSMAdviseExp(
     // Level Zero does not have a completion "event" with the advise API,
     // so manually add command to signal our event.
     ZE2UR_CALL(zeCommandListAppendSignalEvent,
-               (CommandBuffer->ZeComputeCommandList, LaunchEvent->ZeEvent));
+               (CommandBuffer->ZeComputeCommandList, ZeLaunchEvent));
   }
 
   return UR_RESULT_SUCCESS;

--- a/source/adapters/level_zero/command_buffer.cpp
+++ b/source/adapters/level_zero/command_buffer.cpp
@@ -67,7 +67,7 @@ ur_exp_command_buffer_handle_t_::ur_exp_command_buffer_handle_t_(
       ZeCommandListResetEvents(CommandListResetEvents),
       ZeCommandListDesc(ZeDesc), ZeCopyCommandList(CopyCommandList),
       ZeCopyCommandListDesc(ZeCopyDesc), ZeFencesMap(), ZeActiveFence(nullptr),
-      QueueProperties(), SyncPoints(), NextSyncPoint(0),
+      SyncPoints(), NextSyncPoint(0),
       IsUpdatable(Desc ? Desc->isUpdatable : false),
       IsProfilingEnabled(Desc ? Desc->enableProfiling : false),
       IsInOrderCmdList(IsInOrderCmdList) {
@@ -350,21 +350,22 @@ createSyncPoint(ur_command_t CommandType,
 }
 
 ur_result_t ur_exp_command_buffer_handle_t_::chooseCommandList(
-    bool PreferCopyEngine, ze_command_list_handle_t &ZeCommandList) {
+    bool PreferCopyEngine, ze_command_list_handle_t *ZeCommandList) {
   // If the copy engine available, the command is enqueued in the
   // ZeCopyCommandList.
   if (PreferCopyEngine && this->UseCopyEngine()) {
     // We indicate that the ZeCopyCommandList contains commands to be
     // submitted.
     this->MCopyCommandListEmpty = false;
-    ZeCommandList = this->ZeCopyCommandList;
+    *ZeCommandList = this->ZeCopyCommandList;
   }
-  ZeCommandList = this->ZeComputeCommandList;
+  *ZeCommandList = this->ZeComputeCommandList;
+  return UR_RESULT_SUCCESS;
 }
 
-//FIXME Probably overkill?
+// FIXME Probably overkill?
 ur_result_t ur_exp_command_buffer_handle_t_::chooseCommandList(
-    bool PreferCopyEngine, ze_command_list_handle_t &ZeCommandList,
+    bool PreferCopyEngine, ze_command_list_handle_t *ZeCommandList,
     size_t PatternSize) {
   // If the copy engine available and patternsize is valid, the command is
   // enqueued in the ZeCopyCommandList, otherwise enqueue it in the compute
@@ -385,7 +386,7 @@ ur_result_t ur_exp_command_buffer_handle_t_::chooseCommandList(
                 .ZeProperties.maxMemoryFillPatternSize,
         UR_RESULT_ERROR_INVALID_VALUE);
   }
-  chooseCommandList(PreferCopyEngine, ZeCommandList);
+  UR_CALL(chooseCommandList(PreferCopyEngine, ZeCommandList));
 }
 
 // Shared by all memory read/write/copy PI interfaces.
@@ -412,7 +413,7 @@ static ur_result_t enqueueCommandBufferMemCopyHelper(
                             LaunchEvent));
 
     ze_command_list_handle_t ZeCommandList;
-    CommandBuffer->chooseCommandList(PreferCopyEngine, ZeCommandList);
+    UR_CALL(CommandBuffer->chooseCommandList(PreferCopyEngine, &ZeCommandList));
 
     ZE2UR_CALL(zeCommandListAppendMemoryCopy,
                (ZeCommandList, Dst, Src, Size, LaunchEvent->ZeEvent,
@@ -483,7 +484,7 @@ static ur_result_t enqueueCommandBufferMemCopyRectHelper(
                             LaunchEvent));
 
     ze_command_list_handle_t ZeCommandList;
-    CommandBuffer->chooseCommandList(PreferCopyEngine, ZeCommandList);
+    UR_CALL(CommandBuffer->chooseCommandList(PreferCopyEngine, &ZeCommandList));
 
     ZE2UR_CALL(zeCommandListAppendMemoryCopyRegion,
                (ZeCommandList, Dst, &ZeDstRegion, DstPitch, DstSlicePitch, Src,
@@ -510,8 +511,8 @@ static ur_result_t enqueueCommandBufferFillHelper(
             UR_RESULT_ERROR_INVALID_VALUE);
 
   ze_command_list_handle_t ZeCommandList;
-  CommandBuffer->chooseCommandList(PreferCopyEngine, ZeCommandList,
-                                   PatternSize);
+  UR_CALL(CommandBuffer->chooseCommandList(PreferCopyEngine, &ZeCommandList,
+                                           PatternSize));
 
   if (CommandBuffer->IsInOrderCmdList) {
     ZE2UR_CALL(zeCommandListAppendMemoryFill,
@@ -907,7 +908,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendMemBufferCopyRectExp(
   UR_CALL(DstBuffer->getZeHandle(ZeHandleDst, ur_mem_handle_t_::write_only,
                                  CommandBuffer->Device));
 
-  //FIXME Bug
+  // FIXME Bug
   bool PreferCopyEngine = (SrcBuffer->OnHost || SrcBuffer->OnHost);
   PreferCopyEngine |= UseCopyEngineForD2DCopy;
 
@@ -1149,31 +1150,46 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendUSMFillExp(
       SyncPoint);
 }
 
+ur_result_t ur_exp_command_buffer_handle_t_::getFence(
+    ze_command_queue_handle_t &ZeCommandQueue, ze_fence_handle_t &ZeFence) {
+  // If we already have created a fence for this queue, first reset then reuse
+  // it, otherwise create a new fence.
+  //  ZeFence = this->ZeActiveFence;
+  auto ZeWorkloadFenceForQueue = this->ZeFencesMap.find(ZeCommandQueue);
+  if (ZeWorkloadFenceForQueue == this->ZeFencesMap.end()) {
+    ZeStruct<ze_fence_desc_t> ZeFenceDesc;
+    ZE2UR_CALL(zeFenceCreate, (ZeCommandQueue, &ZeFenceDesc, &ZeFence));
+    this->ZeFencesMap.insert({{ZeCommandQueue, ZeFence}});
+  } else {
+    ZeFence = ZeWorkloadFenceForQueue->second;
+    ZE2UR_CALL(zeFenceReset, (ZeFence));
+  }
+  return UR_RESULT_SUCCESS;
+}
+
+ur_result_t ur_exp_command_buffer_handle_t_::getZeCommandQueue(
+    ur_queue_handle_t Queue, bool UseCopyEngine,
+    ze_command_queue_handle_t &ZeCommandQueue) {
+  // Use compute engine rather than copy engine
+  auto &QGroup = Queue->getQueueGroup(UseCopyEngine);
+  uint32_t QueueGroupOrdinal;
+  ZeCommandQueue = QGroup.getZeQueue(&QueueGroupOrdinal);
+  return UR_RESULT_SUCCESS;
+}
+
 UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferEnqueueExp(
     ur_exp_command_buffer_handle_t CommandBuffer, ur_queue_handle_t UrQueue,
     uint32_t NumEventsInWaitList, const ur_event_handle_t *EventWaitList,
     ur_event_handle_t *Event) {
   auto Queue = Legacy(UrQueue);
   std::scoped_lock<ur_shared_mutex> lock(Queue->Mutex);
-  // Use compute engine rather than copy engine
-  const auto UseCopyEngine = false;
-  auto &QGroup = Queue->getQueueGroup(UseCopyEngine);
-  uint32_t QueueGroupOrdinal;
-  auto &ZeCommandQueue = QGroup.getZeQueue(&QueueGroupOrdinal);
 
-  // If we already have created a fence for this queue, first reset then reuse
-  // it, otherwise create a new fence.
-  ze_fence_handle_t &ZeFence = CommandBuffer->ZeActiveFence;
-  auto ZeWorkloadFenceForQueue =
-      CommandBuffer->ZeFencesMap.find(ZeCommandQueue);
-  if (ZeWorkloadFenceForQueue == CommandBuffer->ZeFencesMap.end()) {
-    ZeStruct<ze_fence_desc_t> ZeFenceDesc;
-    ZE2UR_CALL(zeFenceCreate, (ZeCommandQueue, &ZeFenceDesc, &ZeFence));
-    CommandBuffer->ZeFencesMap.insert({{ZeCommandQueue, ZeFence}});
-  } else {
-    ZeFence = ZeWorkloadFenceForQueue->second;
-    ZE2UR_CALL(zeFenceReset, (ZeFence));
-  }
+  const auto UseCopyEngine = false;
+  ze_command_queue_handle_t ZeCommandQueue;
+  CommandBuffer->getZeCommandQueue(Queue, false, ZeCommandQueue);
+
+  ze_fence_handle_t ZeFence;
+  CommandBuffer->getFence(ZeCommandQueue, ZeFence);
 
   bool MustSignalWaitEvent = true;
   if (NumEventsInWaitList) {
@@ -1229,9 +1245,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferEnqueueExp(
   // The Copy command-list is submitted to the main copy queue if it is not
   // empty.
   if (!CommandBuffer->MCopyCommandListEmpty) {
-    auto &QGroupCopy = Queue->getQueueGroup(true);
-    uint32_t QueueGroupOrdinal;
-    auto &ZeCopyCommandQueue = QGroupCopy.getZeQueue(&QueueGroupOrdinal);
+    ze_command_queue_handle_t ZeCopyCommandQueue;
+    CommandBuffer->getZeCommandQueue(Queue, true, ZeCopyCommandQueue);
     ZE2UR_CALL(
         zeCommandQueueExecuteCommandLists,
         (ZeCopyCommandQueue, 1, &CommandBuffer->ZeCopyCommandList, nullptr));

--- a/source/adapters/level_zero/command_buffer.cpp
+++ b/source/adapters/level_zero/command_buffer.cpp
@@ -23,7 +23,7 @@ namespace {
 // Gets a C pointer from a vector. If the vector is empty returns nullptr
 // instead. This is different from the behaviour of the data() member function
 // of the vector class which might not return nullptr when the vector is empty.
-template <typename T> static T *getPointerFromVector(std::vector<T> &V) {
+template <typename T> T *getPointerFromVector(std::vector<T> &V) {
   return V.size() == 0 ? nullptr : V.data();
 }
 
@@ -33,10 +33,10 @@ template <typename T> static T *getPointerFromVector(std::vector<T> &V) {
  * @param[in] VersionMajor Major version number to compare to.
  * @param[in] VersionMinor Minor version number to compare to.
  * @param[in] VersionBuild Build version number to compare to.
- * @return true is the version of the driver is higher than or equal to the
+ * @return true if the version of the driver is higher than or equal to the
  * compared version.
  */
-bool IsDriverVersionNewerOrSimilar(ur_context_handle_t Context,
+bool isDriverVersionNewerOrSimilar(ur_context_handle_t Context,
                                    uint32_t VersionMajor, uint32_t VersionMinor,
                                    uint32_t VersionBuild) {
   ZeStruct<ze_driver_properties_t> ZeDriverProperties;
@@ -64,15 +64,18 @@ bool IsDriverVersionNewerOrSimilar(ur_context_handle_t Context,
  * @return UR_RESULT_SUCCESS or an error code on failure
  */
 ur_result_t
-PreferCopyEngineForFill(ur_exp_command_buffer_handle_t CommandBuffer,
+preferCopyEngineForFill(ur_exp_command_buffer_handle_t CommandBuffer,
                         size_t PatternSize, bool &PreferCopyEngine) {
-  const char *UrRet = std::getenv("UR_L0_USE_COPY_ENGINE_FOR_FILL");
-  const char *PiRet =
-      std::getenv("SYCL_PI_LEVEL_ZERO_USE_COPY_ENGINE_FOR_FILL");
+  assert(PatternSize > 0);
 
-  // If the copy engine available and PatternSize is valid, the command is
-  // enqueued in the ZeCopyCommandList, otherwise enqueue it in the compute
-  // command list.
+  PreferCopyEngine = false;
+  if (!CommandBuffer->UseCopyEngine()) {
+    return UR_RESULT_SUCCESS;
+  }
+
+  // If the copy engine is available, and it supports this pattern size, the
+  // command should be enqueued in the copy command list, otherwise enqueue it
+  // in the compute command list.
   PreferCopyEngine =
       PatternSize <=
       CommandBuffer->Device
@@ -88,6 +91,10 @@ PreferCopyEngineForFill(ur_exp_command_buffer_handle_t CommandBuffer,
                 .ZeProperties.maxMemoryFillPatternSize,
         UR_RESULT_ERROR_INVALID_VALUE);
   }
+
+  const char *UrRet = std::getenv("UR_L0_USE_COPY_ENGINE_FOR_FILL");
+  const char *PiRet =
+      std::getenv("SYCL_PI_LEVEL_ZERO_USE_COPY_ENGINE_FOR_FILL");
 
   PreferCopyEngine =
       PreferCopyEngine &&
@@ -253,7 +260,8 @@ ur_result_t getEventsFromSyncPoints(
 }
 
 /**
- * If needed, creates a sync point for a given command.
+ * If needed, creates a sync point for a given command and returns the L0
+ * events associated with the sync point.
  * This operations is skipped if the command buffer is in order.
  * @param[in] CommandType The type of the command.
  * @param[in] CommandBuffer The CommandBuffer where the command is appended.
@@ -261,41 +269,43 @@ ur_result_t getEventsFromSyncPoints(
  * dependencies for the command.
  * @param[in] SyncPointWaitList List of sync point that are dependencies for the
  * command.
- * @param[out][optional] RetSyncPoint The new sync point.
- * @param[in] host_visible Whether the event associated with the sync point
+ * @param[in] HostVisible Whether the event associated with the sync point
  * should be host visible.
+ * @param[out][optional] RetSyncPoint The new sync point.
  * @param[out] ZeEventList A list of L0 events that are dependencies for this
  * sync point.
  * @param[out] ZeLaunchEvent The L0 event associated with this sync point.
  * @return UR_RESULT_SUCCESS or an error code on failure
  */
-ur_result_t createSyncPointIfNeeded(
+ur_result_t createSyncPointAndGetZeEvents(
     ur_command_t CommandType, ur_exp_command_buffer_handle_t CommandBuffer,
     uint32_t NumSyncPointsInWaitList,
     const ur_exp_command_buffer_sync_point_t *SyncPointWaitList,
-    ur_exp_command_buffer_sync_point_t *RetSyncPoint, bool host_visible,
+    bool HostVisible, ur_exp_command_buffer_sync_point_t *RetSyncPoint,
     std::vector<ze_event_handle_t> &ZeEventList,
     ze_event_handle_t &ZeLaunchEvent) {
 
   ZeLaunchEvent = nullptr;
-  if (!CommandBuffer->IsInOrderCmdList) {
-    UR_CALL(getEventsFromSyncPoints(CommandBuffer, NumSyncPointsInWaitList,
-                                    SyncPointWaitList, ZeEventList));
-    ur_event_handle_t LaunchEvent;
-    UR_CALL(EventCreate(CommandBuffer->Context, nullptr, false, host_visible,
-                        &LaunchEvent, false,
-                        !CommandBuffer->IsProfilingEnabled));
-    LaunchEvent->CommandType = CommandType;
-    ZeLaunchEvent = LaunchEvent->ZeEvent;
 
-    // Get sync point and register the event with it.
-    ur_exp_command_buffer_sync_point_t SyncPoint =
-        CommandBuffer->GetNextSyncPoint();
-    CommandBuffer->RegisterSyncPoint(SyncPoint, LaunchEvent);
+  if (CommandBuffer->IsInOrderCmdList) {
+    return UR_RESULT_SUCCESS;
+  }
 
-    if (RetSyncPoint) {
-      *RetSyncPoint = SyncPoint;
-    }
+  UR_CALL(getEventsFromSyncPoints(CommandBuffer, NumSyncPointsInWaitList,
+                                  SyncPointWaitList, ZeEventList));
+  ur_event_handle_t LaunchEvent;
+  UR_CALL(EventCreate(CommandBuffer->Context, nullptr, false, HostVisible,
+                      &LaunchEvent, false, !CommandBuffer->IsProfilingEnabled));
+  LaunchEvent->CommandType = CommandType;
+  ZeLaunchEvent = LaunchEvent->ZeEvent;
+
+  // Get sync point and register the event with it.
+  ur_exp_command_buffer_sync_point_t SyncPoint =
+      CommandBuffer->GetNextSyncPoint();
+  CommandBuffer->RegisterSyncPoint(SyncPoint, LaunchEvent);
+
+  if (RetSyncPoint) {
+    *RetSyncPoint = SyncPoint;
   }
 
   return UR_RESULT_SUCCESS;
@@ -313,12 +323,12 @@ ur_result_t enqueueCommandBufferMemCopyHelper(
 
   std::vector<ze_event_handle_t> ZeEventList;
   ze_event_handle_t ZeLaunchEvent = nullptr;
-  UR_CALL(createSyncPointIfNeeded(
+  UR_CALL(createSyncPointAndGetZeEvents(
       CommandType, CommandBuffer, NumSyncPointsInWaitList, SyncPointWaitList,
-      RetSyncPoint, false, ZeEventList, ZeLaunchEvent));
+      false, RetSyncPoint, ZeEventList, ZeLaunchEvent));
 
-  ze_command_list_handle_t ZeCommandList;
-  UR_CALL(CommandBuffer->chooseCommandList(PreferCopyEngine, &ZeCommandList));
+  ze_command_list_handle_t ZeCommandList =
+      CommandBuffer->chooseCommandList(PreferCopyEngine);
 
   logger::debug("calling zeCommandListAppendMemoryCopy()");
   ZE2UR_CALL(zeCommandListAppendMemoryCopy,
@@ -372,12 +382,12 @@ ur_result_t enqueueCommandBufferMemCopyRectHelper(
 
   std::vector<ze_event_handle_t> ZeEventList;
   ze_event_handle_t ZeLaunchEvent = nullptr;
-  UR_CALL(createSyncPointIfNeeded(
+  UR_CALL(createSyncPointAndGetZeEvents(
       CommandType, CommandBuffer, NumSyncPointsInWaitList, SyncPointWaitList,
-      RetSyncPoint, false, ZeEventList, ZeLaunchEvent));
+      false, RetSyncPoint, ZeEventList, ZeLaunchEvent));
 
-  ze_command_list_handle_t ZeCommandList;
-  UR_CALL(CommandBuffer->chooseCommandList(PreferCopyEngine, &ZeCommandList));
+  ze_command_list_handle_t ZeCommandList =
+      CommandBuffer->chooseCommandList(PreferCopyEngine);
 
   logger::debug("calling zeCommandListAppendMemoryCopyRegion()");
   ZE2UR_CALL(zeCommandListAppendMemoryCopyRegion,
@@ -401,16 +411,16 @@ ur_result_t enqueueCommandBufferFillHelper(
 
   std::vector<ze_event_handle_t> ZeEventList;
   ze_event_handle_t ZeLaunchEvent = nullptr;
-  UR_CALL(createSyncPointIfNeeded(
+  UR_CALL(createSyncPointAndGetZeEvents(
       CommandType, CommandBuffer, NumSyncPointsInWaitList, SyncPointWaitList,
-      RetSyncPoint, true, ZeEventList, ZeLaunchEvent));
+      true, RetSyncPoint, ZeEventList, ZeLaunchEvent));
 
   bool PreferCopyEngine;
   UR_CALL(
-      PreferCopyEngineForFill(CommandBuffer, PatternSize, PreferCopyEngine));
+      preferCopyEngineForFill(CommandBuffer, PatternSize, PreferCopyEngine));
 
-  ze_command_list_handle_t ZeCommandList;
-  UR_CALL(CommandBuffer->chooseCommandList(PreferCopyEngine, &ZeCommandList));
+  ze_command_list_handle_t ZeCommandList =
+      CommandBuffer->chooseCommandList(PreferCopyEngine);
 
   logger::debug("calling zeCommandListAppendMemoryFill()");
   ZE2UR_CALL(zeCommandListAppendMemoryFill,
@@ -549,15 +559,14 @@ void ur_exp_command_buffer_handle_t_::RegisterSyncPoint(
   ZeEventsList.push_back(Event->ZeEvent);
 }
 
-ur_result_t ur_exp_command_buffer_handle_t_::chooseCommandList(
-    bool PreferCopyEngine, ze_command_list_handle_t *ZeCommandList) {
+ze_command_list_handle_t
+ur_exp_command_buffer_handle_t_::chooseCommandList(bool PreferCopyEngine) {
   if (PreferCopyEngine && this->UseCopyEngine() && !this->IsInOrderCmdList) {
     // We indicate that ZeCopyCommandList contains commands to be submitted.
     this->MCopyCommandListEmpty = false;
-    *ZeCommandList = this->ZeCopyCommandList;
+    return this->ZeCopyCommandList;
   }
-  *ZeCommandList = this->ZeComputeCommandList;
-  return UR_RESULT_SUCCESS;
+  return this->ZeComputeCommandList;
 }
 
 ur_result_t ur_exp_command_buffer_handle_t_::getFenceForQueue(
@@ -584,19 +593,19 @@ namespace {
  * @param[in] Context The Context associated with the command-list
  * @param[in] Device  The Device associated with the command-list
  * @param[in] IsInOrder Whether the command-list should be in-order.
- * @param[in] isUpdatable Whether the command-list should be mutable.
- * @param[in] isCopy Whether to use copy-engine for the the new command-list.
+ * @param[in] IsUpdatable Whether the command-list should be mutable.
+ * @param[in] IsCopy Whether to use copy-engine for the the new command-list.
  * @param[out] CommandList The L0 command-list created by this function.
  * @return UR_RESULT_SUCCESS or an error code on failure
  */
 ur_result_t createMainCommandList(ur_context_handle_t Context,
                                   ur_device_handle_t Device, bool IsInOrder,
-                                  bool isUpdatable, bool isCopy,
+                                  bool IsUpdatable, bool IsCopy,
                                   ze_command_list_handle_t &CommandList) {
 
-  auto type = isCopy ? ur_device_handle_t_::queue_group_info_t::type::MainCopy
+  auto Type = IsCopy ? ur_device_handle_t_::queue_group_info_t::type::MainCopy
                      : ur_device_handle_t_::queue_group_info_t::type::Compute;
-  uint32_t QueueGroupOrdinal = Device->QueueGroup[type].ZeOrdinal;
+  uint32_t QueueGroupOrdinal = Device->QueueGroup[Type].ZeOrdinal;
 
   ZeStruct<ze_command_list_desc_t> ZeCommandListDesc;
   ZeCommandListDesc.commandQueueGroupOrdinal = QueueGroupOrdinal;
@@ -610,7 +619,10 @@ ur_result_t createMainCommandList(ur_context_handle_t Context,
   DEBUG_LOG(ZeCommandListDesc.flags);
 
   ZeStruct<ze_mutable_command_list_exp_desc_t> ZeMutableCommandListDesc;
-  if (isUpdatable) {
+  if (IsUpdatable) {
+    auto Platform = Context->getPlatform();
+    UR_ASSERT(Platform->ZeMutableCmdListExt.Supported,
+              UR_RESULT_ERROR_UNSUPPORTED_FEATURE);
     ZeMutableCommandListDesc.flags = 0;
     ZeCommandListDesc.pNext = &ZeMutableCommandListDesc;
   }
@@ -618,19 +630,6 @@ ur_result_t createMainCommandList(ur_context_handle_t Context,
   ZE2UR_CALL(zeCommandListCreate, (Context->ZeContext, Device->ZeDevice,
                                    &ZeCommandListDesc, &CommandList));
 
-  return UR_RESULT_SUCCESS;
-}
-
-/**
- * Appends a barrier to CommandList that waits for all the Events in EventList
- * @param[in] CommandList The command-list where the barrier should be appended.
- * @param[in] ZeEventList A list of events to wait for.
- * @return UR_RESULT_SUCCESS or an error code on failure
- */
-ur_result_t waitForEvents(ze_command_list_handle_t CommandList,
-                          std::vector<ze_event_handle_t> &ZeEventList) {
-  ZE2UR_CALL(zeCommandListAppendBarrier,
-             (CommandList, nullptr, ZeEventList.size(), ZeEventList.data()));
   return UR_RESULT_SUCCESS;
 }
 
@@ -644,7 +643,7 @@ ur_result_t waitForEvents(ze_command_list_handle_t CommandList,
 bool canBeInOrder(ur_context_handle_t Context,
                   const ur_exp_command_buffer_desc_t *CommandBufferDesc) {
   // In-order command-lists are not available in old driver version.
-  bool CompatibleDriver = IsDriverVersionNewerOrSimilar(Context, 1, 3, 28454);
+  bool CompatibleDriver = isDriverVersionNewerOrSimilar(Context, 1, 3, 28454);
   return CompatibleDriver
              ? (CommandBufferDesc ? CommandBufferDesc->isInOrder : false)
              : false;
@@ -657,7 +656,7 @@ urCommandBufferCreateExp(ur_context_handle_t Context, ur_device_handle_t Device,
                          ur_exp_command_buffer_handle_t *CommandBuffer) {
 
   bool IsInOrder = canBeInOrder(Context, CommandBufferDesc);
-  bool enableProfiling =
+  bool EnableProfiling =
       CommandBufferDesc && CommandBufferDesc->enableProfiling;
   bool IsUpdatable = CommandBufferDesc && CommandBufferDesc->isUpdatable;
 
@@ -666,18 +665,20 @@ urCommandBufferCreateExp(ur_context_handle_t Context, ur_device_handle_t Device,
   ur_event_handle_t AllResetEvent;
 
   UR_CALL(EventCreate(Context, nullptr, false, false, &SignalEvent, false,
-                      !enableProfiling));
+                      !EnableProfiling));
   UR_CALL(EventCreate(Context, nullptr, false, false, &WaitEvent, false,
-                      !enableProfiling));
+                      !EnableProfiling));
   UR_CALL(EventCreate(Context, nullptr, false, false, &AllResetEvent, false,
-                      !enableProfiling));
+                      !EnableProfiling));
   std::vector<ze_event_handle_t> PrecondEvents = {WaitEvent->ZeEvent,
                                                   AllResetEvent->ZeEvent};
 
   ze_command_list_handle_t ZeComputeCommandList = nullptr;
   UR_CALL(createMainCommandList(Context, Device, IsInOrder, IsUpdatable, false,
                                 ZeComputeCommandList));
-  UR_CALL(waitForEvents(ZeComputeCommandList, PrecondEvents));
+  ZE2UR_CALL(zeCommandListAppendBarrier,
+             (ZeComputeCommandList, nullptr, PrecondEvents.size(),
+              PrecondEvents.data()));
 
   ze_command_list_handle_t ZeCommandListResetEvents = nullptr;
   UR_CALL(createMainCommandList(Context, Device, false, false, false,
@@ -692,7 +693,9 @@ urCommandBufferCreateExp(ur_context_handle_t Context, ur_device_handle_t Device,
   if (Device->hasMainCopyEngine()) {
     UR_CALL(createMainCommandList(Context, Device, false, false, true,
                                   ZeCopyCommandList));
-    UR_CALL(waitForEvents(ZeCopyCommandList, PrecondEvents));
+    ZE2UR_CALL(zeCommandListAppendBarrier,
+               (ZeCopyCommandList, nullptr, PrecondEvents.size(),
+                PrecondEvents.data()));
   }
 
   ze_command_list_handle_t ZeComputeCommandListTranslated = nullptr;
@@ -859,10 +862,8 @@ createCommandHandle(ur_exp_command_buffer_handle_t CommandBuffer,
                                ZE_MUTABLE_COMMAND_EXP_FLAG_GROUP_SIZE |
                                ZE_MUTABLE_COMMAND_EXP_FLAG_GLOBAL_OFFSET;
 
-  auto Plt = CommandBuffer->Context->getPlatform();
-  UR_ASSERT(Plt->ZeMutableCmdListExt.Supported,
-            UR_RESULT_ERROR_UNSUPPORTED_FEATURE);
-  ZE2UR_CALL(Plt->ZeMutableCmdListExt.zexCommandListGetNextCommandIdExp,
+  auto Platform = CommandBuffer->Context->getPlatform();
+  ZE2UR_CALL(Platform->ZeMutableCmdListExt.zexCommandListGetNextCommandIdExp,
              (CommandBuffer->ZeComputeCommandListTranslated,
               &ZeMutableCommandDesc, &CommandId));
   DEBUG_LOG(CommandId);
@@ -926,9 +927,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendKernelLaunchExp(
 
   std::vector<ze_event_handle_t> ZeEventList;
   ze_event_handle_t ZeLaunchEvent = nullptr;
-  UR_CALL(createSyncPointIfNeeded(
+  UR_CALL(createSyncPointAndGetZeEvents(
       UR_COMMAND_KERNEL_LAUNCH, CommandBuffer, NumSyncPointsInWaitList,
-      SyncPointWaitList, RetSyncPoint, false, ZeEventList, ZeLaunchEvent));
+      SyncPointWaitList, false, RetSyncPoint, ZeEventList, ZeLaunchEvent));
 
   logger::debug("calling zeCommandListAppendLaunchKernel()");
   ZE2UR_CALL(zeCommandListAppendLaunchKernel,
@@ -1121,9 +1122,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendUSMPrefetchExp(
   } else {
     std::vector<ze_event_handle_t> ZeEventList;
     ze_event_handle_t ZeLaunchEvent = nullptr;
-    UR_CALL(createSyncPointIfNeeded(
+    UR_CALL(createSyncPointAndGetZeEvents(
         UR_COMMAND_USM_PREFETCH, CommandBuffer, NumSyncPointsInWaitList,
-        SyncPointWaitList, RetSyncPoint, true, ZeEventList, ZeLaunchEvent));
+        SyncPointWaitList, true, RetSyncPoint, ZeEventList, ZeLaunchEvent));
 
     if (NumSyncPointsInWaitList) {
       ZE2UR_CALL(zeCommandListAppendWaitOnEvents,
@@ -1184,9 +1185,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendUSMAdviseExp(
   } else {
     std::vector<ze_event_handle_t> ZeEventList;
     ze_event_handle_t ZeLaunchEvent = nullptr;
-    UR_CALL(createSyncPointIfNeeded(
+    UR_CALL(createSyncPointAndGetZeEvents(
         UR_COMMAND_USM_ADVISE, CommandBuffer, NumSyncPointsInWaitList,
-        SyncPointWaitList, RetSyncPoint, true, ZeEventList, ZeLaunchEvent));
+        SyncPointWaitList, true, RetSyncPoint, ZeEventList, ZeLaunchEvent));
 
     if (NumSyncPointsInWaitList) {
       ZE2UR_CALL(zeCommandListAppendWaitOnEvents,
@@ -1370,7 +1371,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferEnqueueExp(
     uint32_t NumEventsInWaitList, const ur_event_handle_t *EventWaitList,
     ur_event_handle_t *Event) {
   auto Queue = Legacy(UrQueue);
-  std::scoped_lock<ur_shared_mutex> lock(Queue->Mutex);
+  std::scoped_lock<ur_shared_mutex> Lock(Queue->Mutex);
 
   ze_command_queue_handle_t ZeCommandQueue;
   getZeCommandQueue(Queue, false, ZeCommandQueue);
@@ -1750,11 +1751,9 @@ ur_result_t updateKernelCommand(
   MutableCommandDesc.pNext = NextDesc;
   MutableCommandDesc.flags = 0;
 
-  auto Plt = CommandBuffer->Context->getPlatform();
-  UR_ASSERT(Plt->ZeMutableCmdListExt.Supported,
-            UR_RESULT_ERROR_UNSUPPORTED_FEATURE);
+  auto Platform = CommandBuffer->Context->getPlatform();
   ZE2UR_CALL(
-      Plt->ZeMutableCmdListExt.zexCommandListUpdateMutableCommandsExp,
+      Platform->ZeMutableCmdListExt.zexCommandListUpdateMutableCommandsExp,
       (CommandBuffer->ZeComputeCommandListTranslated, &MutableCommandDesc));
 
   return UR_RESULT_SUCCESS;

--- a/source/adapters/level_zero/command_buffer.cpp
+++ b/source/adapters/level_zero/command_buffer.cpp
@@ -319,7 +319,7 @@ static ur_result_t getEventsFromSyncPoints(
 
 // FIXME Refactor Naming?
 // FIXME Refactor Why do some events need to be host_visible and others don't
-ur_result_t
+static ur_result_t
 createSyncPoint(ur_command_t CommandType,
                 ur_exp_command_buffer_handle_t CommandBuffer,
                 uint32_t NumSyncPointsInWaitList,
@@ -349,17 +349,43 @@ createSyncPoint(ur_command_t CommandType,
   return UR_RESULT_SUCCESS;
 }
 
-ze_command_list_handle_t
-ur_exp_command_buffer_handle_t_::chooseCommandList(Ubool PreferCopyEngine) {
+ur_result_t ur_exp_command_buffer_handle_t_::chooseCommandList(
+    bool PreferCopyEngine, ze_command_list_handle_t &ZeCommandList) {
   // If the copy engine available, the command is enqueued in the
   // ZeCopyCommandList.
   if (PreferCopyEngine && this->UseCopyEngine()) {
     // We indicate that the ZeCopyCommandList contains commands to be
     // submitted.
     this->MCopyCommandListEmpty = false;
-    return this->ZeCopyCommandList;
+    ZeCommandList = this->ZeCopyCommandList;
   }
-  return this->ZeComputeCommandList;
+  ZeCommandList = this->ZeComputeCommandList;
+}
+
+//FIXME Probably overkill?
+ur_result_t ur_exp_command_buffer_handle_t_::chooseCommandList(
+    bool PreferCopyEngine, ze_command_list_handle_t &ZeCommandList,
+    size_t PatternSize) {
+  // If the copy engine available and patternsize is valid, the command is
+  // enqueued in the ZeCopyCommandList, otherwise enqueue it in the compute
+  // command list.
+  PreferCopyEngine =
+      PreferCopyEngine &&
+      PatternSize <=
+          this->Device
+              ->QueueGroup[ur_device_handle_t_::queue_group_info_t::MainCopy]
+              .ZeProperties.maxMemoryFillPatternSize;
+
+  if (!PreferCopyEngine) {
+    // Pattern size must fit the compute queue capabilities.
+    UR_ASSERT(
+        PatternSize <=
+            this->Device
+                ->QueueGroup[ur_device_handle_t_::queue_group_info_t::Compute]
+                .ZeProperties.maxMemoryFillPatternSize,
+        UR_RESULT_ERROR_INVALID_VALUE);
+  }
+  chooseCommandList(PreferCopyEngine, ZeCommandList);
 }
 
 // Shared by all memory read/write/copy PI interfaces.
@@ -385,8 +411,8 @@ static ur_result_t enqueueCommandBufferMemCopyHelper(
                             SyncPointWaitList, RetSyncPoint, false, ZeEventList,
                             LaunchEvent));
 
-    ze_command_list_handle_t ZeCommandList =
-        CommandBuffer->chooseCommandList(PreferCopyEngine);
+    ze_command_list_handle_t ZeCommandList;
+    CommandBuffer->chooseCommandList(PreferCopyEngine, ZeCommandList);
 
     ZE2UR_CALL(zeCommandListAppendMemoryCopy,
                (ZeCommandList, Dst, Src, Size, LaunchEvent->ZeEvent,
@@ -450,15 +476,14 @@ static ur_result_t enqueueCommandBufferMemCopyRectHelper(
     logger::debug("calling zeCommandListAppendMemoryCopyRegion()");
   } else {
     // FIXME Why doesn't the event need to be host visible
-
     std::vector<ze_event_handle_t> ZeEventList;
     ur_event_handle_t LaunchEvent;
     UR_CALL(createSyncPoint(CommandType, CommandBuffer, NumSyncPointsInWaitList,
                             SyncPointWaitList, RetSyncPoint, false, ZeEventList,
                             LaunchEvent));
 
-    ze_command_list_handle_t ZeCommandList =
-        CommandBuffer->chooseCommandList(PreferCopyEngine);
+    ze_command_list_handle_t ZeCommandList;
+    CommandBuffer->chooseCommandList(PreferCopyEngine, ZeCommandList);
 
     ZE2UR_CALL(zeCommandListAppendMemoryCopyRegion,
                (ZeCommandList, Dst, &ZeDstRegion, DstPitch, DstSlicePitch, Src,
@@ -484,27 +509,9 @@ static ur_result_t enqueueCommandBufferFillHelper(
   UR_ASSERT((PatternSize > 0) && ((PatternSize & (PatternSize - 1)) == 0),
             UR_RESULT_ERROR_INVALID_VALUE);
 
-  // If the copy engine available and patternsize is valid, the command is
-  // enqueued in the ZeCopyCommandList, otherwise enqueue it in the compute
-  // command list.
-  PreferCopyEngine =
-      PreferCopyEngine &&
-      PatternSize <=
-          CommandBuffer->Device
-              ->QueueGroup[ur_device_handle_t_::queue_group_info_t::MainCopy]
-              .ZeProperties.maxMemoryFillPatternSize;
-
-  if (!PreferCopyEngine) {
-    // Pattern size must fit the compute queue capabilities.
-    UR_ASSERT(
-        PatternSize <=
-            CommandBuffer->Device
-                ->QueueGroup[ur_device_handle_t_::queue_group_info_t::Compute]
-                .ZeProperties.maxMemoryFillPatternSize,
-        UR_RESULT_ERROR_INVALID_VALUE);
-  }
-  ze_command_list_handle_t ZeCommandList =
-      CommandBuffer->chooseCommandList(PreferCopyEngine);
+  ze_command_list_handle_t ZeCommandList;
+  CommandBuffer->chooseCommandList(PreferCopyEngine, ZeCommandList,
+                                   PatternSize);
 
   if (CommandBuffer->IsInOrderCmdList) {
     ZE2UR_CALL(zeCommandListAppendMemoryFill,
@@ -841,8 +848,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendUSMMemcpyExp(
 
   bool PreferCopyEngine = !IsDevicePointer(CommandBuffer->Context, Src) ||
                           !IsDevicePointer(CommandBuffer->Context, Dst);
-
-
   PreferCopyEngine |= UseCopyEngineForD2DCopy;
 
   return enqueueCommandBufferMemCopyHelper(
@@ -870,8 +875,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendMemBufferCopyExp(
   UR_CALL(DstBuffer->getZeHandle(ZeHandleDst, ur_mem_handle_t_::write_only,
                                  CommandBuffer->Device));
 
+  // FIXME Bug
   bool PreferCopyEngine = (SrcBuffer->OnHost || SrcBuffer->OnHost);
-
   PreferCopyEngine |= UseCopyEngineForD2DCopy;
 
   return enqueueCommandBufferMemCopyHelper(
@@ -902,8 +907,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendMemBufferCopyRectExp(
   UR_CALL(DstBuffer->getZeHandle(ZeHandleDst, ur_mem_handle_t_::write_only,
                                  CommandBuffer->Device));
 
+  //FIXME Bug
   bool PreferCopyEngine = (SrcBuffer->OnHost || SrcBuffer->OnHost);
-
   PreferCopyEngine |= UseCopyEngineForD2DCopy;
 
   return enqueueCommandBufferMemCopyRectHelper(

--- a/source/adapters/level_zero/command_buffer.cpp
+++ b/source/adapters/level_zero/command_buffer.cpp
@@ -58,16 +58,15 @@ ur_exp_command_buffer_handle_t_::ur_exp_command_buffer_handle_t_(
     ze_command_list_handle_t CommandList,
     ze_command_list_handle_t CommandListTranslated,
     ze_command_list_handle_t CommandListResetEvents,
-    ze_command_list_handle_t CopyCommandList,
-    ZeStruct<ze_command_list_desc_t> ZeDesc,
-    ZeStruct<ze_command_list_desc_t> ZeCopyDesc,
+    ze_command_list_handle_t CopyCommandList, ur_event_handle_t SignalEvent,
+    ur_event_handle_t WaitEvent, ur_event_handle_t AllResetEvent,
     const ur_exp_command_buffer_desc_t *Desc, const bool IsInOrderCmdList)
     : Context(Context), Device(Device), ZeComputeCommandList(CommandList),
       ZeComputeCommandListTranslated(CommandListTranslated),
       ZeCommandListResetEvents(CommandListResetEvents),
-      ZeCommandListDesc(ZeDesc), ZeCopyCommandList(CopyCommandList),
-      ZeCopyCommandListDesc(ZeCopyDesc), ZeFencesMap(), ZeActiveFence(nullptr),
-      SyncPoints(), NextSyncPoint(0),
+      ZeCopyCommandList(CopyCommandList), SignalEvent(SignalEvent),
+      WaitEvent(WaitEvent), AllResetEvent(AllResetEvent), ZeFencesMap(),
+      ZeActiveFence(nullptr), SyncPoints(), NextSyncPoint(0),
       IsUpdatable(Desc ? Desc->isUpdatable : false),
       IsProfilingEnabled(Desc ? Desc->enableProfiling : false),
       IsInOrderCmdList(IsInOrderCmdList) {
@@ -540,29 +539,17 @@ static ur_result_t enqueueCommandBufferFillHelper(
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
-urCommandBufferCreateExp(ur_context_handle_t Context, ur_device_handle_t Device,
-                         const ur_exp_command_buffer_desc_t *CommandBufferDesc,
-                         ur_exp_command_buffer_handle_t *CommandBuffer) {
-  // In-order command-lists are not available in old driver version.
-  bool CompatibleDriver = IsDriverVersionNewerOrSimilar(Context, 1, 3, 28454);
-  const bool IsInOrder =
-      CompatibleDriver
-          ? (CommandBufferDesc ? CommandBufferDesc->isInOrder : false)
-          : false;
+static ur_result_t
+createMainCommandList(ur_context_handle_t Context, ur_device_handle_t Device,
+                      bool IsInOrder, bool isUpdatable, bool isCopy,
+                      ze_command_list_handle_t &CommandList) {
 
-  uint32_t QueueGroupOrdinal =
-      Device->QueueGroup[ur_device_handle_t_::queue_group_info_t::type::Compute]
-          .ZeOrdinal;
+  auto type = isCopy ? ur_device_handle_t_::queue_group_info_t::type::MainCopy
+                     : ur_device_handle_t_::queue_group_info_t::type::Compute;
+  uint32_t QueueGroupOrdinal = Device->QueueGroup[type].ZeOrdinal;
 
   ZeStruct<ze_command_list_desc_t> ZeCommandListDesc;
   ZeCommandListDesc.commandQueueGroupOrdinal = QueueGroupOrdinal;
-
-  ze_command_list_handle_t ZeCommandListResetEvents;
-  // Create a command-list for reseting the events associated to enqueued cmd.
-  ZE2UR_CALL(zeCommandListCreate,
-             (Context->ZeContext, Device->ZeDevice, &ZeCommandListDesc,
-              &ZeCommandListResetEvents));
 
   // For non-linear graph, dependencies between commands are explicitly enforced
   // by sync points when enqueuing. Consequently, relax the command ordering in
@@ -573,41 +560,77 @@ urCommandBufferCreateExp(ur_context_handle_t Context, ur_device_handle_t Device,
   DEBUG_LOG(ZeCommandListDesc.flags);
 
   ZeStruct<ze_mutable_command_list_exp_desc_t> ZeMutableCommandListDesc;
-  if (CommandBufferDesc && CommandBufferDesc->isUpdatable) {
+  if (isUpdatable) {
     ZeMutableCommandListDesc.flags = 0;
     ZeCommandListDesc.pNext = &ZeMutableCommandListDesc;
   }
 
-  ze_command_list_handle_t ZeComputeCommandList;
-  // TODO We could optimize this by pooling both Level Zero command-lists and UR
-  // command-buffers, then reusing them.
   ZE2UR_CALL(zeCommandListCreate, (Context->ZeContext, Device->ZeDevice,
-                                   &ZeCommandListDesc, &ZeComputeCommandList));
+                                   &ZeCommandListDesc, &CommandList));
 
-  // Create a list for copy commands.
-  // Note that to simplify the implementation, the current implementation only
-  // uses the main copy engine and does not use the link engine even if
-  // available.
+  return UR_RESULT_SUCCESS;
+}
+
+static ur_result_t
+appendPreconditionEvents(ze_command_list_handle_t CommandList,
+                         ur_event_handle_t WaitEvent,
+                         ur_event_handle_t AllResetEvent) {
+  std::vector<ze_event_handle_t> PrecondEvents = {WaitEvent->ZeEvent,
+                                                  AllResetEvent->ZeEvent};
+  ZE2UR_CALL(
+      zeCommandListAppendBarrier,
+      (CommandList, nullptr, PrecondEvents.size(), PrecondEvents.data()));
+}
+
+static bool
+enableInOrder(ur_context_handle_t Context,
+              const ur_exp_command_buffer_desc_t *CommandBufferDesc) {
+  // In-order command-lists are not available in old driver version.
+  bool CompatibleDriver = IsDriverVersionNewerOrSimilar(Context, 1, 3, 28454);
+  return CompatibleDriver
+             ? (CommandBufferDesc ? CommandBufferDesc->isInOrder : false)
+             : false;
+}
+UR_APIEXPORT ur_result_t UR_APICALL
+urCommandBufferCreateExp(ur_context_handle_t Context, ur_device_handle_t Device,
+                         const ur_exp_command_buffer_desc_t *CommandBufferDesc,
+                         ur_exp_command_buffer_handle_t *CommandBuffer) {
+
+  ur_event_handle_t SignalEvent;
+  ur_event_handle_t WaitEvent;
+  ur_event_handle_t AllResetEvent;
+
+  UR_CALL(EventCreate(Context, nullptr, false, false, &SignalEvent, false,
+                      !CommandBufferDesc->enableProfiling));
+  UR_CALL(EventCreate(Context, nullptr, false, false, &WaitEvent, false,
+                      !CommandBufferDesc->enableProfiling));
+  UR_CALL(EventCreate(Context, nullptr, false, false, &AllResetEvent, false,
+                      !CommandBufferDesc->enableProfiling));
+
+  bool IsInOrder = enableInOrder(Context, CommandBufferDesc);
+  bool IsUpdatable = CommandBufferDesc && CommandBufferDesc->isUpdatable;
+
+  ze_command_list_handle_t ZeComputeCommandList = nullptr;
+  UR_CALL(createMainCommandList(Context, Device, IsInOrder, IsUpdatable, false,
+                                ZeComputeCommandList));
+  UR_CALL(
+      appendPreconditionEvents(ZeComputeCommandList, WaitEvent, AllResetEvent));
+
+  ze_command_list_handle_t ZeCommandListResetEvents = nullptr;
+  UR_CALL(createMainCommandList(Context, Device, false, false, false,
+                                ZeCommandListResetEvents));
+  ZE2UR_CALL(zeCommandListAppendEventReset,
+             (ZeCommandListResetEvents, SignalEvent->ZeEvent));
+
+  // Create a list for copy commands. Note that to simplify the implementation,
+  // the current implementation only uses the main copy engine and does not use
+  // the link engine even if available.
   ze_command_list_handle_t ZeCopyCommandList = nullptr;
-  ZeStruct<ze_command_list_desc_t> ZeCopyCommandListDesc;
   if (Device->hasMainCopyEngine()) {
-    uint32_t QueueGroupOrdinalCopy =
-        Device
-            ->QueueGroup
-                [ur_device_handle_t_::queue_group_info_t::type::MainCopy]
-            .ZeOrdinal;
-
-    ZeCopyCommandListDesc.commandQueueGroupOrdinal = QueueGroupOrdinalCopy;
-    // Dependencies between commands are explicitly enforced by sync points when
-    // enqueuing. Consequently, relax the command ordering in the command list
-    // can enable the backend to further optimize the workload
-    ZeCopyCommandListDesc.flags = ZE_COMMAND_LIST_FLAG_RELAXED_ORDERING;
-
-    // TODO We could optimize this by pooling both Level Zero command-lists and
-    // UR command-buffers, then reusing them.
-    ZE2UR_CALL(zeCommandListCreate,
-               (Context->ZeContext, Device->ZeDevice, &ZeCopyCommandListDesc,
-                &ZeCopyCommandList));
+    UR_CALL(createMainCommandList(Context, Device, false, false, true,
+                                  ZeCopyCommandList));
+    UR_CALL(
+        appendPreconditionEvents(ZeCopyCommandList, WaitEvent, AllResetEvent));
   }
 
   ze_command_list_handle_t ZeComputeCommandListTranslated = nullptr;
@@ -618,46 +641,14 @@ urCommandBufferCreateExp(ur_context_handle_t Context, ur_device_handle_t Device,
   try {
     *CommandBuffer = new ur_exp_command_buffer_handle_t_(
         Context, Device, ZeComputeCommandList, ZeComputeCommandListTranslated,
-        ZeCommandListResetEvents, ZeCopyCommandList, ZeCommandListDesc,
-        ZeCopyCommandListDesc, CommandBufferDesc, IsInOrder);
+        ZeCommandListResetEvents, ZeCopyCommandList, SignalEvent, WaitEvent,
+        AllResetEvent, CommandBufferDesc, IsInOrder);
   } catch (const std::bad_alloc &) {
     return UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
   } catch (...) {
     return UR_RESULT_ERROR_UNKNOWN;
   }
 
-  // Create signal & wait events to be used in the command-list for sync
-  // on command-buffer enqueue.
-  auto RetCommandBuffer = *CommandBuffer;
-  UR_CALL(EventCreate(Context, nullptr, false, false,
-                      &RetCommandBuffer->SignalEvent, false,
-                      !RetCommandBuffer->IsProfilingEnabled));
-  UR_CALL(EventCreate(Context, nullptr, false, false,
-                      &RetCommandBuffer->WaitEvent, false,
-                      !RetCommandBuffer->IsProfilingEnabled));
-  UR_CALL(EventCreate(Context, nullptr, false, false,
-                      &RetCommandBuffer->AllResetEvent, false,
-                      !RetCommandBuffer->IsProfilingEnabled));
-
-  // Add prefix commands
-  ZE2UR_CALL(
-      zeCommandListAppendEventReset,
-      (ZeCommandListResetEvents, RetCommandBuffer->SignalEvent->ZeEvent));
-  std::vector<ze_event_handle_t> PrecondEvents = {
-      RetCommandBuffer->WaitEvent->ZeEvent,
-      RetCommandBuffer->AllResetEvent->ZeEvent};
-  ZE2UR_CALL(zeCommandListAppendBarrier,
-             (ZeComputeCommandList, nullptr, PrecondEvents.size(),
-              PrecondEvents.data()));
-
-  if (Device->hasMainCopyEngine()) {
-    // The copy command-list must be executed once the preconditions have been
-    // met. We therefore begin this command-list with a barrier on the
-    // preconditions.
-    ZE2UR_CALL(zeCommandListAppendBarrier,
-               (ZeCopyCommandList, nullptr, PrecondEvents.size(),
-                PrecondEvents.data()));
-  }
   return UR_RESULT_SUCCESS;
 }
 
@@ -876,7 +867,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendMemBufferCopyExp(
   UR_CALL(DstBuffer->getZeHandle(ZeHandleDst, ur_mem_handle_t_::write_only,
                                  CommandBuffer->Device));
 
-  // FIXME Bug
   bool PreferCopyEngine = (SrcBuffer->OnHost || SrcBuffer->OnHost);
   PreferCopyEngine |= UseCopyEngineForD2DCopy;
 
@@ -908,7 +898,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendMemBufferCopyRectExp(
   UR_CALL(DstBuffer->getZeHandle(ZeHandleDst, ur_mem_handle_t_::write_only,
                                  CommandBuffer->Device));
 
-  // FIXME Bug
   bool PreferCopyEngine = (SrcBuffer->OnHost || SrcBuffer->OnHost);
   PreferCopyEngine |= UseCopyEngineForD2DCopy;
 
@@ -1164,6 +1153,7 @@ ur_result_t ur_exp_command_buffer_handle_t_::getFence(
     ZeFence = ZeWorkloadFenceForQueue->second;
     ZE2UR_CALL(zeFenceReset, (ZeFence));
   }
+  this->ZeActiveFence = ZeFence;
   return UR_RESULT_SUCCESS;
 }
 
@@ -1273,7 +1263,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferEnqueueExp(
   auto Queue = Legacy(UrQueue);
   std::scoped_lock<ur_shared_mutex> lock(Queue->Mutex);
 
-  const auto UseCopyEngine = false;
   ze_command_queue_handle_t ZeCommandQueue;
   CommandBuffer->getZeCommandQueue(Queue, false, ZeCommandQueue);
 
@@ -1309,10 +1298,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferEnqueueExp(
         (ZeCopyCommandQueue, 1, &CommandBuffer->ZeCopyCommandList, nullptr));
   }
 
-  // Execution event for this enqueue of the UR command-buffer
-  ur_event_handle_t RetEvent{};
-
-  // Create a command-list to signal RetEvent on completion
+  // Create a command-list to signal the Event on completion
   ur_command_list_ptr_t SignalCommandList{};
   UR_CALL(Queue->Context->getAvailableCommandList(Queue, SignalCommandList,
                                                   false, NumEventsInWaitList,

--- a/source/adapters/level_zero/command_buffer.hpp
+++ b/source/adapters/level_zero/command_buffer.hpp
@@ -28,7 +28,6 @@ struct ur_exp_command_buffer_handle_t_ : public _ur_object {
   ur_exp_command_buffer_handle_t_(
       ur_context_handle_t Context, ur_device_handle_t Device,
       ze_command_list_handle_t CommandList,
-      ze_command_list_handle_t CommandListTranslated,
       ze_command_list_handle_t CommandListResetEvents,
       ze_command_list_handle_t CopyCommandList, ur_event_handle_t SignalEvent,
       ur_event_handle_t WaitEvent, ur_event_handle_t AllResetEvent,
@@ -71,9 +70,6 @@ struct ur_exp_command_buffer_handle_t_ : public _ur_object {
   ur_device_handle_t Device;
   // Level Zero command list handle
   ze_command_list_handle_t ZeComputeCommandList;
-  // Given a multi driver scenario, the driver handle must be translated to the
-  // internal driver handle to allow calls to driver experimental apis.
-  ze_command_list_handle_t ZeComputeCommandListTranslated;
   // Level Zero command list handle
   ze_command_list_handle_t ZeCommandListResetEvents;
   // Level Zero Copy command list handle

--- a/source/adapters/level_zero/command_buffer.hpp
+++ b/source/adapters/level_zero/command_buffer.hpp
@@ -31,8 +31,9 @@ struct ur_exp_command_buffer_handle_t_ : public _ur_object {
       ze_command_list_handle_t CommandListTranslated,
       ze_command_list_handle_t CommandListResetEvents,
       ze_command_list_handle_t CopyCommandList,
-      ZeStruct<ze_command_list_desc_t> ZeDesc,
-      ZeStruct<ze_command_list_desc_t> ZeCopyDesc,
+      ur_event_handle_t SignalEvent,
+      ur_event_handle_t WaitEvent,
+      ur_event_handle_t AllResetEvent,
       const ur_exp_command_buffer_desc_t *Desc, const bool IsInOrderCmdList);
 
   ~ur_exp_command_buffer_handle_t_();
@@ -70,12 +71,17 @@ struct ur_exp_command_buffer_handle_t_ : public _ur_object {
   ze_command_list_handle_t ZeComputeCommandListTranslated;
   // Level Zero command list handle
   ze_command_list_handle_t ZeCommandListResetEvents;
-  // Level Zero command list descriptor
-  ZeStruct<ze_command_list_desc_t> ZeCommandListDesc;
   // Level Zero Copy command list handle
   ze_command_list_handle_t ZeCopyCommandList;
-  // Level Zero Copy command list descriptor
-  ZeStruct<ze_command_list_desc_t> ZeCopyCommandListDesc;
+  // Event which will signals the most recent execution of the command-buffer
+  // has finished
+  ur_event_handle_t SignalEvent = nullptr;
+  // Event which a command-buffer waits on until the wait-list dependencies
+  // passed to a command-buffer enqueue have been satisfied.
+  ur_event_handle_t WaitEvent = nullptr;
+  // Event which a command-buffer waits on until the main command-list event
+  // have been reset.
+  ur_event_handle_t AllResetEvent = nullptr;
   // This flag is must be set to false if at least one copy command has been
   // added to `ZeCopyCommandList`
   bool MCopyCommandListEmpty = true;
@@ -94,15 +100,7 @@ struct ur_exp_command_buffer_handle_t_ : public _ur_object {
   ur_exp_command_buffer_sync_point_t NextSyncPoint;
   // List of Level Zero events associated to submitted commands.
   std::vector<ze_event_handle_t> ZeEventsList;
-  // Event which will signals the most recent execution of the command-buffer
-  // has finished
-  ur_event_handle_t SignalEvent = nullptr;
-  // Event which a command-buffer waits on until the wait-list dependencies
-  // passed to a command-buffer enqueue have been satisfied.
-  ur_event_handle_t WaitEvent = nullptr;
-  // Event which a command-buffer waits on until the main command-list event
-  // have been reset.
-  ur_event_handle_t AllResetEvent = nullptr;
+
   // Indicates if command-buffer commands can be updated after it is closed.
   bool IsUpdatable = false;
   // Indicates if command buffer was finalized.

--- a/source/adapters/level_zero/command_buffer.hpp
+++ b/source/adapters/level_zero/command_buffer.hpp
@@ -36,12 +36,6 @@ struct ur_exp_command_buffer_handle_t_ : public _ur_object {
 
   ~ur_exp_command_buffer_handle_t_();
 
-//  void RegisterSyncPoint(ur_exp_command_buffer_sync_point_t SyncPoint,
-//                         ur_event_handle_t Event) {
-//    SyncPoints[SyncPoint] = Event;
-//    NextSyncPoint++;
-//  }
-
   void RegisterSyncPoint(ur_exp_command_buffer_sync_point_t SyncPoint,
                          ur_event_handle_t Event);
 
@@ -52,16 +46,26 @@ struct ur_exp_command_buffer_handle_t_ : public _ur_object {
   // Indicates if a copy engine is available for use
   bool UseCopyEngine() const { return ZeCopyCommandList != nullptr; }
 
-  // FIXME Refactor Documentation
-  ur_result_t getFence(ze_command_queue_handle_t &ZeCommandQueue,
-                       ze_fence_handle_t &ZeFence);
-  ur_result_t getZeCommandQueue(ur_queue_handle_t Queue, bool UseCopyEngine,
-                                ze_command_queue_handle_t &ZeCommandQueue);
+  /**
+   * Obtains a fence for a specific L0 queue. If there is already an available
+   * fence for this queue, it will be reused.
+   * @param[in] ZeCommandQueue The L0 queue associated with the fence.
+   * @param[out] ZeFence The fence.
+   * @return UR_RESULT_SUCCESS or an error code on failure
+   */
+  ur_result_t getFenceForQueue(ze_command_queue_handle_t &ZeCommandQueue,
+                               ze_fence_handle_t &ZeFence);
+
+  /**
+   * Chooses which command list to use when appending a command to this command
+   * buffer.
+   * @param[in] PreferCopyEngine If true, will try to choose a copy engine
+   * command-list. Will choose a compute command-list otherwise.
+   * @param[out] ZeCommandList The chosen command list.
+   * @return UR_RESULT_SUCCESS or an error code on failure
+   */
   ur_result_t chooseCommandList(bool PreferCopyEngine,
                                 ze_command_list_handle_t *ZeCommandList);
-  ur_result_t chooseCommandList(bool PreferCopyEngine,
-                                ze_command_list_handle_t *ZeCommandList,
-                                size_t PatternSize);
 
   // UR context associated with this command-buffer
   ur_context_handle_t Context;

--- a/source/adapters/level_zero/command_buffer.hpp
+++ b/source/adapters/level_zero/command_buffer.hpp
@@ -50,6 +50,9 @@ struct ur_exp_command_buffer_handle_t_ : public _ur_object {
   // Indicates if a copy engine is available for use
   bool UseCopyEngine() const { return ZeCopyCommandList != nullptr; }
 
+  //FIXME Refactor Documentation
+  ze_command_list_handle_t chooseCommandList(bool PreferCopyEngine);
+
   // UR context associated with this command-buffer
   ur_context_handle_t Context;
   // Device associated with this command buffer

--- a/source/adapters/level_zero/command_buffer.hpp
+++ b/source/adapters/level_zero/command_buffer.hpp
@@ -30,19 +30,20 @@ struct ur_exp_command_buffer_handle_t_ : public _ur_object {
       ze_command_list_handle_t CommandList,
       ze_command_list_handle_t CommandListTranslated,
       ze_command_list_handle_t CommandListResetEvents,
-      ze_command_list_handle_t CopyCommandList,
-      ur_event_handle_t SignalEvent,
-      ur_event_handle_t WaitEvent,
-      ur_event_handle_t AllResetEvent,
+      ze_command_list_handle_t CopyCommandList, ur_event_handle_t SignalEvent,
+      ur_event_handle_t WaitEvent, ur_event_handle_t AllResetEvent,
       const ur_exp_command_buffer_desc_t *Desc, const bool IsInOrderCmdList);
 
   ~ur_exp_command_buffer_handle_t_();
 
+//  void RegisterSyncPoint(ur_exp_command_buffer_sync_point_t SyncPoint,
+//                         ur_event_handle_t Event) {
+//    SyncPoints[SyncPoint] = Event;
+//    NextSyncPoint++;
+//  }
+
   void RegisterSyncPoint(ur_exp_command_buffer_sync_point_t SyncPoint,
-                         ur_event_handle_t Event) {
-    SyncPoints[SyncPoint] = Event;
-    NextSyncPoint++;
-  }
+                         ur_event_handle_t Event);
 
   ur_exp_command_buffer_sync_point_t GetNextSyncPoint() const {
     return NextSyncPoint;
@@ -52,8 +53,10 @@ struct ur_exp_command_buffer_handle_t_ : public _ur_object {
   bool UseCopyEngine() const { return ZeCopyCommandList != nullptr; }
 
   // FIXME Refactor Documentation
-  ur_result_t getFence(ze_command_queue_handle_t & ZeCommandQueue, ze_fence_handle_t &ZeFence);
-  ur_result_t getZeCommandQueue(ur_queue_handle_t Queue, bool UseCopyEngine, ze_command_queue_handle_t& ZeCommandQueue);
+  ur_result_t getFence(ze_command_queue_handle_t &ZeCommandQueue,
+                       ze_fence_handle_t &ZeFence);
+  ur_result_t getZeCommandQueue(ur_queue_handle_t Queue, bool UseCopyEngine,
+                                ze_command_queue_handle_t &ZeCommandQueue);
   ur_result_t chooseCommandList(bool PreferCopyEngine,
                                 ze_command_list_handle_t *ZeCommandList);
   ur_result_t chooseCommandList(bool PreferCopyEngine,
@@ -98,7 +101,7 @@ struct ur_exp_command_buffer_handle_t_ : public _ur_object {
   // Next sync_point value (may need to consider ways to reuse values if 32-bits
   // is not enough)
   ur_exp_command_buffer_sync_point_t NextSyncPoint;
-  // List of Level Zero events associated to submitted commands.
+  // List of Level Zero events associated with submitted commands.
   std::vector<ze_event_handle_t> ZeEventsList;
 
   // Indicates if command-buffer commands can be updated after it is closed.

--- a/source/adapters/level_zero/command_buffer.hpp
+++ b/source/adapters/level_zero/command_buffer.hpp
@@ -50,8 +50,12 @@ struct ur_exp_command_buffer_handle_t_ : public _ur_object {
   // Indicates if a copy engine is available for use
   bool UseCopyEngine() const { return ZeCopyCommandList != nullptr; }
 
-  //FIXME Refactor Documentation
-  ze_command_list_handle_t chooseCommandList(bool PreferCopyEngine);
+  // FIXME Refactor Documentation
+  ur_result_t chooseCommandList(bool PreferCopyEngine,
+                                ze_command_list_handle_t &ZeCommandList);
+  ur_result_t chooseCommandList(bool PreferCopyEngine,
+                                ze_command_list_handle_t &ZeCommandList,
+                                size_t PatternSize);
 
   // UR context associated with this command-buffer
   ur_context_handle_t Context;

--- a/source/adapters/level_zero/command_buffer.hpp
+++ b/source/adapters/level_zero/command_buffer.hpp
@@ -51,10 +51,12 @@ struct ur_exp_command_buffer_handle_t_ : public _ur_object {
   bool UseCopyEngine() const { return ZeCopyCommandList != nullptr; }
 
   // FIXME Refactor Documentation
+  ur_result_t getFence(ze_command_queue_handle_t & ZeCommandQueue, ze_fence_handle_t &ZeFence);
+  ur_result_t getZeCommandQueue(ur_queue_handle_t Queue, bool UseCopyEngine, ze_command_queue_handle_t& ZeCommandQueue);
   ur_result_t chooseCommandList(bool PreferCopyEngine,
-                                ze_command_list_handle_t &ZeCommandList);
+                                ze_command_list_handle_t *ZeCommandList);
   ur_result_t chooseCommandList(bool PreferCopyEngine,
-                                ze_command_list_handle_t &ZeCommandList,
+                                ze_command_list_handle_t *ZeCommandList,
                                 size_t PatternSize);
 
   // UR context associated with this command-buffer
@@ -84,9 +86,6 @@ struct ur_exp_command_buffer_handle_t_ : public _ur_object {
   // Must be an element in ZeFencesMap, so is not required to be destroyed
   // itself.
   ze_fence_handle_t ZeActiveFence;
-  // Queue properties from command-buffer descriptor
-  // TODO: Do we need these?
-  ur_queue_properties_t QueueProperties;
   // Map of sync_points to ur_events
   std::unordered_map<ur_exp_command_buffer_sync_point_t, ur_event_handle_t>
       SyncPoints;

--- a/source/adapters/level_zero/command_buffer.hpp
+++ b/source/adapters/level_zero/command_buffer.hpp
@@ -61,11 +61,9 @@ struct ur_exp_command_buffer_handle_t_ : public _ur_object {
    * buffer.
    * @param[in] PreferCopyEngine If true, will try to choose a copy engine
    * command-list. Will choose a compute command-list otherwise.
-   * @param[out] ZeCommandList The chosen command list.
-   * @return UR_RESULT_SUCCESS or an error code on failure
+   * @return The chosen command list.
    */
-  ur_result_t chooseCommandList(bool PreferCopyEngine,
-                                ze_command_list_handle_t *ZeCommandList);
+  ze_command_list_handle_t chooseCommandList(bool PreferCopyEngine);
 
   // UR context associated with this command-buffer
   ur_context_handle_t Context;


### PR DESCRIPTION
Dependent on merging the refactor for command-buffers first.

Always use the translated driver command-lists instead of having 2 separate variable.